### PR TITLE
Insert closing ul tag in quick links

### DIFF
--- a/datatables.html
+++ b/datatables.html
@@ -127,6 +127,7 @@
         <ul>
             <li><a href="index.html#profile">Portfolio</a></li>
             <li><a href="datatables.html">DataTables Demo</a></li>
+        </ul>
 
          
     </div>


### PR DESCRIPTION
## Summary
- fix missing `</ul>` in quick links section of `datatables.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848e0fc04608329809ff25c1eb3da89