### PR TITLE
Improve certificates section with filtering

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,6 +139,12 @@
         .then(response => response.text())
         .then(data => document.getElementById("certificates").innerHTML = data);
     </script>
+<div id="seminar-section"></div>
+<script>
+fetch("sections/seminars.html")
+    .then(response => response.text())
+    .then(data => document.getElementById("seminar-section").innerHTML = data);
+</script>
 
     
     <section id="achievements" data-aos="fade-left" data-aos-duration="800" data-aos-delay="200">
@@ -419,6 +425,7 @@
 
     </script>
     <script src="js/image-modal.js"></script>
+    <script src="js/certificates.js"></script>
 
     <script>
             function openGmail() {

--- a/js/certificates.js
+++ b/js/certificates.js
@@ -1,0 +1,31 @@
+// Filter and search functionality for certificate cards
+
+document.addEventListener('DOMContentLoaded', function () {
+  const searchInput = document.getElementById('certificateSearch');
+  const tagCheckboxes = document.querySelectorAll('.tag-filter');
+  const cards = document.querySelectorAll('#certificateGrid .certificate-card');
+
+  function filterCards() {
+    const query = searchInput.value.toLowerCase();
+    const selectedTags = Array.from(tagCheckboxes)
+      .filter(cb => cb.checked)
+      .map(cb => cb.value);
+
+    cards.forEach(card => {
+      const title = card.querySelector('h3').textContent.toLowerCase();
+      const tags = (card.dataset.tags || '').split(',').map(t => t.trim());
+
+      const matchesSearch = title.includes(query);
+      const matchesTags = selectedTags.length === 0 ||
+        selectedTags.some(tag => tags.includes(tag));
+
+      card.style.display = (matchesSearch && matchesTags) ? 'block' : 'none';
+    });
+  }
+
+  if (searchInput) {
+    searchInput.addEventListener('input', filterCards);
+  }
+
+  tagCheckboxes.forEach(cb => cb.addEventListener('change', filterCards));
+});

--- a/sections/certificates.html
+++ b/sections/certificates.html
@@ -8,8 +8,17 @@
 >
   <h2>Certificates</h2>
   <p class="description">Certificates that I received in my career.</p>
+  <div class="filter-container">
+    <input type="text" id="certificateSearch" placeholder="Search certificates...">
+    <div class="tag-container">
+      <label><input type="checkbox" class="tag-filter" value="Programming">Programming</label>
+      <label><input type="checkbox" class="tag-filter" value="Data">Data</label>
+      <label><input type="checkbox" class="tag-filter" value="Cloud">Cloud</label>
+      <label><input type="checkbox" class="tag-filter" value="Security">Security</label>
+    </div>
+  </div>
   <div class="certificate-grid">
-    <div class="certificate-card">
+    <div class="certificate-card" data-tags="Programming">
       <h3>FreeCodeCamp - JavaScript Algorithms and Data Structures</h3>
       <p class="details-placeholder">
         This certificate demonstrates proficiency in JavaScript algorithms, data
@@ -23,7 +32,7 @@
         >View Certificate</a
       >
     </div>
-    <div class="certificate-card">
+    <div class="certificate-card" data-tags="Data">
       <h3>Data Analytics Essentials - Cisco</h3>
       <p class="details-placeholder">
         This certificate verifies foundational knowledge and essential skills in
@@ -38,7 +47,7 @@
       >
     </div>
 
-    <div class="certificate-card">
+    <div class="certificate-card" data-tags="Programming,Data">
       <h3>FreeCodeCamp - Scientific Computing with Python</h3>
       <p class="details-placeholder">
         This certificate demonstrates proficiency in using Python.
@@ -51,7 +60,7 @@
         >View Certificate</a
       >
     </div>
-    <div class="certificate-card">
+    <div class="certificate-card" data-tags="Programming">
       <h3>FreeCodeCamp - Web Responsive Design</h3>
       <p class="details-placeholder">
         This certificate demonstrates proficiency in responsive web design using
@@ -65,7 +74,7 @@
         >View Certificate</a
       >
     </div>
-    <div class="certificate-card">
+    <div class="certificate-card" data-tags="Data">
       <h3>Visualize Your Data</h3>
       <p class="details-placeholder">
         This course covers essential tools and techniques for visualizing data
@@ -80,7 +89,7 @@
       >
     </div>
 
-    <div class="certificate-card">
+    <div class="certificate-card" data-tags="Data">
       <h3>Coding for Data</h3>
       <p class="details-placeholder">
         Coding is an important part of data analysis, and can be used in a
@@ -90,7 +99,7 @@
       <a href="static/coding_for_data.jpg" class="view-image">View Image</a>
     </div>
 
-    <div class="certificate-card">
+    <div class="certificate-card" data-tags="Programming">
       <h3>Intro to C</h3>
       <p class="details-placeholder">
         C is a general-purpose programming language. It was created in the 1970s
@@ -101,7 +110,7 @@
         >View Image</a
       >
     </div>
-    <div class="certificate-card">
+    <div class="certificate-card" data-tags="Security">
       <h3>Civil Service Professional Examination</h3>
       <p class="details-placeholder">
         Successfully passed the Civil Service Professional Examination,
@@ -114,7 +123,7 @@
       >
     </div>
 
-    <div class="certificate-card">
+    <div class="certificate-card" data-tags="Cloud,Programming">
       <h3>Gemini for end-to-end SDLC - Google Cloud</h3>
       <p class="details-placeholder">
         I learned how to develop and build a web application, fix errors in the
@@ -127,7 +136,7 @@
       >
     </div>
 
-    <div class="certificate-card">
+    <div class="certificate-card" data-tags="Security">
       <h3>LFC108 Cybersecurity Essentials - Linux Foundations</h3>
       <p class="details-placeholder">
         Cybersecurity Essentials include the fundamental and core skills to
@@ -139,7 +148,7 @@
       >
     </div>
 
-    <div class="certificate-card">
+    <div class="certificate-card" data-tags="Programming">
       <h3>Frontend for Beginners - Solo Learn</h3>
       <p class="details-placeholder">
         Front-end web development is the development of the graphical user
@@ -152,7 +161,7 @@
       >
     </div>
 
-    <div class="certificate-card">
+    <div class="certificate-card" data-tags="Programming">
       <h3>Web Development - Solo Learn</h3>
       <p class="details-placeholder">
         Web development is the work involved in developing a website for the
@@ -164,7 +173,7 @@
       >
     </div>
 
-    <div class="certificate-card">
+    <div class="certificate-card" data-tags="Cloud">
       <h3>Digital Transformation with Google Cloud</h3>
       <p class="details-placeholder">
         This course provides an overview of the types of opportunities and
@@ -177,7 +186,7 @@
       >
     </div>
 
-    <div class="certificate-card">
+    <div class="certificate-card" data-tags="Programming">
       <h3>Python Core - Solo Learn</h3>
       <p class="details-placeholder">
         Python is a high-level, general-purpose programming language. Its design
@@ -190,7 +199,7 @@
       >
     </div>
 
-    <div class="certificate-card">
+    <div class="certificate-card" data-tags="Data">
       <h3>Foundations of Geographic Information System</h3>
       <p class="details-placeholder">
         A Geographic Information System (GIS) is a computer system that analyzes
@@ -202,7 +211,7 @@
       >
     </div>
 
-    <div class="certificate-card">
+    <div class="certificate-card" data-tags="Data">
       <h3>Intel OpenVINO Training</h3>
       <p class="details-placeholder">
         OpenVINO is an open-source software toolkit for optimizing and deploying
@@ -214,7 +223,7 @@
       >
     </div>
 
-    <div class="certificate-card">
+    <div class="certificate-card" data-tags="Programming">
       <h3>Python for Beginners- Solo Learn</h3>
       <p class="details-placeholder">
         Python is a high-level, general-purpose programming language. Its design
@@ -223,132 +232,6 @@
         Date: August 2022
       </p>
       <a href="static/python-1.png" target="_blank" class="view-image"
-        >View Image</a
-      >
-    </div>
-  </div>
-  <h2 id="seminar">Seminars and Workshops</h2>
-  <p class="description">
-    Seminars and workshops that I attended in my career.
-  </p>
-  <div class="certificate-grid">
-    <div class="certificate-card">
-      <h3>Workshop #1 Design Thinking Workshop | BPI DATA Wave 2024</h3>
-      <p class="details-placeholder">
-        Design Thinking Workshop of BPI DATA Wave <br />
-        Date: September 2024
-      </p>
-    </div>
-
-    <div class="certificate-card">
-      <h3>Decode 2024</h3>
-      <p class="details-placeholder">
-        The Philippines' Largest Cybersecurity Conference. <br />
-        Date: June 2024
-      </p>
-    </div>
-
-    <div class="certificate-card">
-      <h3>Animation Industry Roadshow</h3>
-      <p class="details-placeholder">
-        Animation is a filmmaking technique by which still images are
-        manipulated to create moving images.<br />
-        Date: June 2024
-      </p>
-    </div>
-
-    <div class="certificate-card">
-      <h3>
-        Capacity Building on the Full Usage of the Marine Biodiversity Website
-      </h3>
-      <p class="details-placeholder">
-        TIt is a project under the Applied Biodiversity ReseArch for Holistic
-        Advancements in Mindanao (ABRAHAM) Program which oversees projects
-        assessing and documenting the reef fish diversity in Davao Region and
-        the Sulu Archipelago<br />
-        Date: September 2023
-      </p>
-    </div>
-
-    <div class="certificate-card">
-      <h3>No more code chaos: Git Good and Stay Organized</h3>
-      <p class="details-placeholder">
-        Campus DevCon 2023 <br />
-        Date: May 2023
-      </p>
-      <a href="static/sem4.png" target="_blank" class="view-image"
-        >View Image</a
-      >
-    </div>
-
-    <div class="certificate-card">
-      <h3>
-        Revolutionizing the Future: Exploring the Power of AI Tools and their
-        Impact
-      </h3>
-      <p class="details-placeholder">
-        Campus DevCon 2023 <br />
-        Date: May 2023
-      </p>
-      <a href="static/sem1.png" target="_blank" class="view-image"
-        >View Image</a
-      >
-    </div>
-
-    <div class="certificate-card">
-      <h3>
-        Introduction to Cybersecurity: Building Awareness in Today’s Digital
-        World
-      </h3>
-      <p class="details-placeholder">
-        Campus DevCon 2023 <br />
-        Date: May 2023
-      </p>
-      <a href="static/sem2.png" target="_blank" class="view-image"
-        >View Image</a
-      >
-    </div>
-
-    <div class="certificate-card">
-      <h3>Your Path in Technopreneurship</h3>
-      <p class="details-placeholder">
-        Campus DevCon 2023 <br />
-        Date: May 2023
-      </p>
-      <a href="static/sem3.png" target="_blank" class="view-image"
-        >View Image</a
-      >
-    </div>
-
-    <div class="certificate-card">
-      <h3>DevSecOps for Starters</h3>
-      <p class="details-placeholder">
-        Campus DevCon 2023 <br />
-        Date: May 2023
-      </p>
-      <a href="static/sem5.png" target="_blank" class="view-image"
-        >View Image</a
-      >
-    </div>
-
-    <div class="certificate-card">
-      <h3>Careers in Cloud Computing</h3>
-      <p class="details-placeholder">
-        Campus DevCon 2023 <br />
-        Date: May 2023
-      </p>
-      <a href="static/sem7.png" target="_blank" class="view-image"
-        >View Image</a
-      >
-    </div>
-
-    <div class="certificate-card">
-      <h3>Your Path in Technopreneurship</h3>
-      <p class="details-placeholder">
-        Campus DevCon 2023 <br />
-        Date: May 2023
-      </p>
-      <a href="static/sem6.png" target="_blank" class="view-image"
         >View Image</a
       >
     </div>

--- a/sections/seminars.html
+++ b/sections/seminars.html
@@ -1,0 +1,128 @@
+<section id="seminar" data-aos="fade-up" data-aos-duration="800" data-aos-delay="100">
+  <h2 id="seminar">Seminars and Workshops</h2>
+  <p class="description">
+    Seminars and workshops that I attended in my career.
+  </p>
+  <div class="certificate-grid">
+    <div class="certificate-card">
+      <h3>Workshop #1 Design Thinking Workshop | BPI DATA Wave 2024</h3>
+      <p class="details-placeholder">
+        Design Thinking Workshop of BPI DATA Wave <br />
+        Date: September 2024
+      </p>
+    </div>
+
+    <div class="certificate-card">
+      <h3>Decode 2024</h3>
+      <p class="details-placeholder">
+        The Philippines' Largest Cybersecurity Conference. <br />
+        Date: June 2024
+      </p>
+    </div>
+
+    <div class="certificate-card">
+      <h3>Animation Industry Roadshow</h3>
+      <p class="details-placeholder">
+        Animation is a filmmaking technique by which still images are
+        manipulated to create moving images.<br />
+        Date: June 2024
+      </p>
+    </div>
+
+    <div class="certificate-card">
+      <h3>
+        Capacity Building on the Full Usage of the Marine Biodiversity Website
+      </h3>
+      <p class="details-placeholder">
+        TIt is a project under the Applied Biodiversity ReseArch for Holistic
+        Advancements in Mindanao (ABRAHAM) Program which oversees projects
+        assessing and documenting the reef fish diversity in Davao Region and
+        the Sulu Archipelago<br />
+        Date: September 2023
+      </p>
+    </div>
+
+    <div class="certificate-card">
+      <h3>No more code chaos: Git Good and Stay Organized</h3>
+      <p class="details-placeholder">
+        Campus DevCon 2023 <br />
+        Date: May 2023
+      </p>
+      <a href="static/sem4.png" target="_blank" class="view-image"
+        >View Image</a
+      >
+    </div>
+
+    <div class="certificate-card">
+      <h3>
+        Revolutionizing the Future: Exploring the Power of AI Tools and their
+        Impact
+      </h3>
+      <p class="details-placeholder">
+        Campus DevCon 2023 <br />
+        Date: May 2023
+      </p>
+      <a href="static/sem1.png" target="_blank" class="view-image"
+        >View Image</a
+      >
+    </div>
+
+    <div class="certificate-card">
+      <h3>
+        Introduction to Cybersecurity: Building Awareness in Today’s Digital
+        World
+      </h3>
+      <p class="details-placeholder">
+        Campus DevCon 2023 <br />
+        Date: May 2023
+      </p>
+      <a href="static/sem2.png" target="_blank" class="view-image"
+        >View Image</a
+      >
+    </div>
+
+    <div class="certificate-card">
+      <h3>Your Path in Technopreneurship</h3>
+      <p class="details-placeholder">
+        Campus DevCon 2023 <br />
+        Date: May 2023
+      </p>
+      <a href="static/sem3.png" target="_blank" class="view-image"
+        >View Image</a
+      >
+    </div>
+
+    <div class="certificate-card">
+      <h3>DevSecOps for Starters</h3>
+      <p class="details-placeholder">
+        Campus DevCon 2023 <br />
+        Date: May 2023
+      </p>
+      <a href="static/sem5.png" target="_blank" class="view-image"
+        >View Image</a
+      >
+    </div>
+
+    <div class="certificate-card">
+      <h3>Careers in Cloud Computing</h3>
+      <p class="details-placeholder">
+        Campus DevCon 2023 <br />
+        Date: May 2023
+      </p>
+      <a href="static/sem7.png" target="_blank" class="view-image"
+        >View Image</a
+      >
+    </div>
+
+    <div class="certificate-card">
+      <h3>Your Path in Technopreneurship</h3>
+      <p class="details-placeholder">
+        Campus DevCon 2023 <br />
+        Date: May 2023
+      </p>
+      <a href="static/sem6.png" target="_blank" class="view-image"
+        >View Image</a
+      >
+    </div>
+  </div>
+</section>

--- a/static/index.css
+++ b/static/index.css
@@ -880,3 +880,28 @@ body {
     color: white;
     text-decoration: underline;
 }
+
+/* Certificate filter styles */
+.filter-container {
+    margin: 20px 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+.filter-container input[type="text"] {
+    padding: 6px 10px;
+    border-radius: 4px;
+    border: 1px solid #555;
+    background-color: var(--onyx);
+    color: var(--text);
+}
+
+.tag-container label {
+    margin-right: 10px;
+    font-size: 0.9rem;
+}
+
+.tag-container input {
+    margin-right: 4px;
+}


### PR DESCRIPTION
## Summary
- add certificate filtering controls and tags
- extract seminars section into its own HTML file
- add JS to handle search and tag filtering
- load new seminar section dynamically
- style filter interface

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6848e20c88408329a5539a15b3f8b0cd