### PR TITLE
Enhance skills interactivity and update project images

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,6 +122,7 @@
 
             tabContents.forEach((tab) => {
               tab.style.display = "none";
+              tab.classList.remove("active");
             });
 
             tabLinks.forEach((tab) => {
@@ -133,6 +134,8 @@
             );
             if (targetTab) {
               targetTab.style.display = "block";
+              // allow CSS transition to play
+              setTimeout(() => targetTab.classList.add("active"), 10);
               evt.currentTarget.classList.add("active");
             }
           }

--- a/project-details/albany-airbnb-dashboard.html
+++ b/project-details/albany-airbnb-dashboard.html
@@ -50,7 +50,7 @@
         <div class="col-lg-8 text-center">
           <div class="container-fluid d-flex flex-row">
             <img
-              src="../static/python-1.png"
+              src="../static/django.png"
               alt="Albany Airbnb Dashboard Screenshot"
               class="img-fluid rounded shadow"
               style="max-width: 350px; height: auto"

--- a/project-details/mcdonalds-sentiment-analysis.html
+++ b/project-details/mcdonalds-sentiment-analysis.html
@@ -50,7 +50,7 @@
         <div class="col-lg-8 text-center">
           <div class="container-fluid d-flex flex-row">
             <img
-              src="../static/python-2.png"
+              src="../static/django.png"
               alt="McDonald's Sentiment Analysis Screenshot"
               class="img-fluid rounded shadow"
               style="max-width: 350px; height: auto"

--- a/sections/projects.html
+++ b/sections/projects.html
@@ -357,7 +357,7 @@
 
     <div class="project-card">
       <div class="project-card-header">
-        <img src="static/python-1.png" alt="Albany Airbnb Dashboard Image" class="project-card-image" />
+        <img src="static/django.png" alt="Albany Airbnb Dashboard Image" class="project-card-image" />
         <h5>Albany Airbnb Dashboard</h5>
       </div>
 
@@ -368,7 +368,14 @@
       <div class="project-tags" style="margin-top: 10px">
         <span class="tag">Pandas</span>
         <span class="tag">Data Visualization</span>
+        <span class="tag">Chart.js</span>
+        <span class="tag">Leaflet</span>
+        <span class="tag">HTML</span>
+        <span class="tag">CSS</span>
+        <span class="tag">JavaScript</span>
         <span class="tag">Front-End</span>
+        <span class="tag">School Project</span>
+        <span class="tag">Python</span>
       </div>
       <div class="project-footer">
         <a href="#" target="_blank" class="btn btn-secondary align-self-end disabled" disabled>View on GitHub</a>
@@ -378,7 +385,7 @@
 
     <div class="project-card">
       <div class="project-card-header">
-        <img src="static/python-2.png" alt="McDonald's Sentiment Analysis Image" class="project-card-image" />
+        <img src="static/django.png" alt="McDonald's Sentiment Analysis Image" class="project-card-image" />
         <h5>McDonald's Sentiment Analysis</h5>
       </div>
 
@@ -390,6 +397,13 @@
         <span class="tag">NLTK</span>
         <span class="tag">VADER</span>
         <span class="tag">Orange</span>
+        <span class="tag">Python</span>
+        <span class="tag">Sentiment Analysis</span>
+        <span class="tag">Data Visualization</span>
+        <span class="tag">Pandas</span>
+        <span class="tag">Machine Learning</span>
+        <span class="tag">Google Reviews</span>
+        <span class="tag">Data Mining</span>
       </div>
       <div class="project-footer">
         <a href="#" target="_blank" class="btn btn-secondary align-self-end disabled" disabled>View on GitHub</a>

--- a/static/index.css
+++ b/static/index.css
@@ -278,9 +278,15 @@ p {
 /* Tab content styling */
 .tabcontent {
     display: none;
+    opacity: 0;
     padding: 20px;
     border-top: none;
     color: white;
+    transition: opacity 0.5s ease;
+}
+
+.tabcontent.active {
+    opacity: 1;
 }
 
 /* Flexbox for side-by-side layout */
@@ -323,11 +329,23 @@ p {
 .tabcontent ul li {
     padding: 8px 0;
     font-size: 18px;
+    transition: transform 0.3s, color 0.3s;
+    cursor: pointer;
+}
+
+.tabcontent ul li:hover {
+    transform: translateX(5px);
+    color: var(--text);
 }
 
 .tabcontent ul li i {
     margin-right: 10px;
     color: var(--text);
+    transition: transform 0.3s;
+}
+
+.tabcontent ul li:hover i {
+    transform: scale(1.2);
 }
 
 /* Media Queries for Responsive Design */


### PR DESCRIPTION
## Summary
- add fade animations and hover effects for skills
- update skills tab JavaScript to enable transitions
- switch placeholder images to `django.png`
- expand project tags to 10 entries for two projects

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688c704cb18c83299bd586ac85c4c77f