### PR TITLE
Update certificates page limit

### DIFF
--- a/js/certificates.js
+++ b/js/certificates.js
@@ -61,7 +61,8 @@ function initCertificates() {
   });
 
   let currentPage = 1;
-  const cardsPerPage = 6;
+  // Number of certificate cards displayed per page
+  const cardsPerPage = 8;
 
   function getFilteredCards() {
     const query = searchInput.value.toLowerCase();


### PR DESCRIPTION
## Summary
- show 8 certificates per page instead of 6

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688c8d6136a083299e70f754ea2d7837