### PR TITLE
Fix online scores display

### DIFF
--- a/js/progress-update.js
+++ b/js/progress-update.js
@@ -1,13 +1,20 @@
-document.addEventListener("DOMContentLoaded", function () {
-  document.querySelectorAll('.progress-item').forEach(function(item) {
+// Display progress in a "current/total (percent%)" format for clarity
+function updateProgress() {
+  document.querySelectorAll('.progress-item').forEach(function (item) {
     const bar = item.querySelector('progress');
     const text = item.querySelector('.progress-text');
     if (!bar || !text) return;
-    if (text.textContent.trim().endsWith('%')) {
-      const percent = Math.round((bar.value / bar.max) * 100);
-      text.textContent = percent + '%';
-    } else {
-      text.textContent = bar.value + '/' + bar.max;
-    }
+
+    // Calculate percentage based on the progress element values
+    const percent = Math.round((bar.value / bar.max) * 100);
+
+    // Always show both the raw value and percentage for readability
+    text.textContent = `${bar.value}/${bar.max} (${percent}%)`;
   });
-});
+}
+
+if (document.readyState !== 'loading') {
+  updateProgress();
+} else {
+  document.addEventListener('DOMContentLoaded', updateProgress);
+}

--- a/static/index.css
+++ b/static/index.css
@@ -562,6 +562,7 @@ p {
 
 #progress {
     background-color: var(--onyx);
+    color: var(--text);
 }
 
 #progress h2{
@@ -585,12 +586,15 @@ p {
 
 .progress-item span {
     white-space: nowrap;
+    color: var(--text);
 }
 
 progress {
     -webkit-appearance: none;
     appearance: none;
-    width: 100%;
+    flex: 1;
+    width: auto;
+    min-width: 0;
     height: 20px;
 }
 


### PR DESCRIPTION
## Summary
- compute percentage for progress bars
- ensure script runs after DOM load
- tweak progress bar styles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688c94d906c88329959558b714284524