### PR TITLE
Fix skill tab interference with progress section

### DIFF
--- a/index.html
+++ b/index.html
@@ -243,10 +243,10 @@
     >
       <h2>Progress</h2>
       <div class="tabs">
-        <button class="tablinks" onclick="openTab(event, 'capture')">
+        <button class="tablinks" onclick="openProgressTab(event, 'capture')">
           Online Scores
         </button>
-        <button class="tablinks" onclick="openTab(event, 'other')">
+        <button class="tablinks" onclick="openProgressTab(event, 'other')">
           Progress
         </button>
       </div>
@@ -424,30 +424,7 @@
       });
     </script>
 
-    <script>
-      function openTab(evt, tabName) {
-        // Get all elements with class="tabcontent" and hide them
-        var tabcontent = document.getElementsByClassName("tabcontent");
-        for (var i = 0; i < tabcontent.length; i++) {
-          tabcontent[i].style.display = "none";
-        }
-
-        // Get all elements with class="tablinks" and remove the class "active"
-        var tablinks = document.getElementsByClassName("tablinks");
-        for (var i = 0; i < tablinks.length; i++) {
-          tablinks[i].className = tablinks[i].className.replace(" active", "");
-        }
-
-        // Show the current tab and add an "active" class to the button that opened the tab
-        document.getElementById(tabName).style.display = "block";
-        evt.currentTarget.className += " active";
-      }
-
-      // Set default open tab
-      document.addEventListener("DOMContentLoaded", function () {
-        document.querySelector(".tablinks").click();
-      });
-    </script>
+    <script src="js/progress-tabs.js"></script>
     <script src="js/image-modal.js"></script>
     <script src="js/progress-update.js"></script>
 

--- a/js/progress-tabs.js
+++ b/js/progress-tabs.js
@@ -1,0 +1,28 @@
+function openProgressTab(evt, tabName) {
+  const progressSection = document.getElementById('progress');
+  if (!progressSection) return;
+
+  const tabcontent = progressSection.querySelectorAll('.tabcontent');
+  tabcontent.forEach((tab) => {
+    tab.style.display = 'none';
+  });
+
+  const tablinks = progressSection.querySelectorAll('.tablinks');
+  tablinks.forEach((link) => {
+    link.className = link.className.replace(' active', '');
+  });
+
+  const target = progressSection.querySelector('#' + CSS.escape(tabName));
+  if (target) {
+    target.style.display = 'block';
+  }
+
+  if (evt.currentTarget) {
+    evt.currentTarget.className += ' active';
+  }
+}
+
+document.addEventListener('DOMContentLoaded', function () {
+  const firstTab = document.querySelector('#progress .tablinks');
+  if (firstTab) firstTab.click();
+});


### PR DESCRIPTION
## Summary
- add new `progress-tabs.js` to manage progress tab state
- reference the new script from `index.html`
- scope progress tab logic to the progress section
- call `openProgressTab` for progress buttons

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688ca84542688329b87eeee5e991752c