### PR TITLE
Add detailed Itinerary Planner info and skills

### DIFF
--- a/project-details/itinerary-planner.html
+++ b/project-details/itinerary-planner.html
@@ -58,11 +58,11 @@
             <div class="mt-2" style="background-color: var(--text); margin-bottom: 0">
               <p class="lead">
                 <strong>Overview:</strong><br />
-                This is a placeholder overview for Laravel Itinerary Planner.
+                Laravel 12 web app for organizing trips, activities, bookings, and budgets with interactive maps and charts.
               </p>
               <p>
                 <strong>Collaborators:</strong><br />
-                Placeholder Collaborators
+                Solo project
               </p>
             </div>
           </div>
@@ -72,11 +72,21 @@
     <section>
       <div class="container">
         <h1 style="color: var(--charcoal)">Introduction</h1>
-        <p>Placeholder introduction text for Laravel Itinerary Planner.</p>
+        <p>
+          Itinerary Planner lets authenticated users create trips, plan daily
+          activities, manage bookings and participants, and track budgets in one
+          place. Locations are set through a draggable Leaflet map and spending
+          insights are visualized with Chart.js.
+        </p>
       </div>
       <div class="container">
         <h1 style="color: var(--charcoal)">Details</h1>
-        <p>More details about this project will be provided soon.</p>
+        <ul>
+          <li>CRUD management for itineraries, activities, bookings, and group members.</li>
+          <li>Budget entries grouped by category with Excel and PDF export options.</li>
+          <li>Dashboard with search and date filters plus dark/light theme support.</li>
+          <li>Responsive Tailwind CSS and Alpine.js front end built with Vite.</li>
+        </ul>
       </div>
     </section>
 

--- a/project-details/itinerary-planner.md
+++ b/project-details/itinerary-planner.md
@@ -1,0 +1,44 @@
+# Itinerary Planner
+
+A full-stack travel planning web application built with Laravel 12 and a Tailwind CSS/Alpine.js front end. It helps travelers organize trips, plan activities, track budgets, and export itineraries.
+
+## Features
+
+- User authentication via Laravel Breeze for secure itinerary ownership
+- Create, edit, delete, and view itineraries with date ranges, photos, and descriptions
+- Map-based activity planning with draggable Leaflet markers
+- Booking management for lodging and other reservations
+- Group member tracking with notes and photos
+- Budget tracking with category summaries and Chart.js visualizations
+- Export itineraries and budgets to Excel and PDF
+- Dashboard with search and date filters
+- Dark/Light theme with responsive Tailwind UI
+
+## Architecture
+
+- Controllers: ItineraryController, ActivityController, BookingController, GroupMemberController, BudgetEntryController, DashboardController
+- Models: Itinerary, Activity, Booking, BudgetEntry, GroupMember, User
+- Exports: ItineraryExport using maatwebsite/excel
+- Front end: Tailwind CSS, Alpine.js, Vite
+- Mapping: Leaflet
+- Charts: Chart.js
+
+## Technology Stack
+
+| Layer | Tools |
+| --- | --- |
+| Framework | Laravel 12 |
+| Frontend | Tailwind CSS, Alpine.js, Vite |
+| Mapping | Leaflet |
+| Charts | Chart.js |
+| Export | maatwebsite/excel, barryvdh/laravel-dompdf |
+| Auth | Laravel Breeze |
+| Database | MySQL |
+
+## Status
+
+Ongoing personal project for exploring Laravel and full-stack development.
+
+## Repository
+
+[GitHub - Seanneskie/itinerary-planner](https://github.com/Seanneskie/itinerary-planner)

--- a/sections/projects.html
+++ b/sections/projects.html
@@ -341,13 +341,19 @@
       </div>
 
       <div class="project-description">
-        <p>A personal hobby project to learn Laravel and PHP by building a travel itinerary planner.</p>
+        <p>Full-stack travel planning app with interactive maps, budgeting, and exportable itineraries.</p>
       </div>
 
       <div class="project-tags" style="margin-top: 10px">
         <span class="tag">Laravel</span>
         <span class="tag">PHP</span>
         <span class="tag">MySQL</span>
+        <span class="tag">Tailwind CSS</span>
+        <span class="tag">Alpine.js</span>
+        <span class="tag">Leaflet</span>
+        <span class="tag">Chart.js</span>
+        <span class="tag">Excel Export</span>
+        <span class="tag">PDF Export</span>
       </div>
       <div class="project-footer">
         <a href="https://github.com/Seanneskie/itinerary-planner" target="_blank" class="btn btn-secondary">View on GitHub</a>

--- a/sections/skills.html
+++ b/sections/skills.html
@@ -58,6 +58,7 @@
                         <li><i  class="devicon-nextjs-plain"></i> Next.js 15</li>
                         <li><i class="devicon-nodejs-plain colored"></i> Node.js</li>
                         <li><i class="devicon-angularjs-plain colored"></i> AngularJS</li>
+                        <li><i class="devicon-alpinejs-original colored"></i> Alpine.js</li>
                         <li><i class="devicon-laravel-plain colored"></i> Laravel</li>
                         <li><i class="fas fa-map"></i> Leaflet</li>
                     </ul>
@@ -182,6 +183,7 @@
                     <ul>
                         <li><i class="devicon-git-plain colored"></i> Git</li>
                         <li><i class="devicon-docker-plain colored"></i> Docker</li>
+                        <li><i class="devicon-vitejs-plain colored"></i> Vite</li>
                         <li><i class="devicon-googlecloud-plain colored"></i> Google Cloud</li>
                         <li><i class="fas fa-cloud-upload-alt"></i> Render</li>
                         <li><i class="devicon-vercel-plain colored"></i> Vercel</li>


### PR DESCRIPTION
## Summary
- Expand Laravel Itinerary Planner project card with richer description and technology tags.
- Fill in the Itinerary Planner detail page and add comprehensive markdown documentation.
- Update skills section to include Alpine.js and Vite.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68900edf6394832992685d964282f7c4