### PR TITLE
Hide progress section and enhance mobile UX

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,13 +30,13 @@
   </head>
   <body style="width: 100vw; overflow-x: hidden">
     <div class="cover">
-      <div class="intro-message">
-        <h1 style="font-size: 64px">Dev Portfolio</h1>
+      <div class="intro-message" data-aos="fade-down">
+        <h1>Dev Portfolio</h1>
         <p>I'm a passionate developer building innovative solutions.</p>
       </div>
     </div>
 
-    <div class="links">
+    <div class="links" data-aos="fade-up">
       <ul>
         <li><a href="#profile">Profile</a></li>
         <li><a href="#projects">Projects</a></li>
@@ -45,7 +45,7 @@
         <li><a href="#courses">Courses</a></li>
         <li><a href="#achievements">Achievements</a></li>
         <li><a href="#work-experiences">Work Experiences</a></li>
-        <li><a href="#progress">Progress</a></li>
+        <!-- <li><a href="#progress">Progress</a></li> -->
       </ul>
     </div>
 
@@ -235,6 +235,7 @@
       </div>
     </section>
 
+    <!--
     <section
       id="progress"
       data-aos="fade-up"
@@ -351,6 +352,7 @@
         </div>
       </div>
     </section>
+    -->
     <footer class="footer">
       <div class="container">
         <div class="footer-row">
@@ -424,9 +426,9 @@
       });
     </script>
 
-    <script src="js/progress-tabs.js"></script>
+    <!-- <script src="js/progress-tabs.js"></script> -->
     <script src="js/image-modal.js"></script>
-    <script src="js/progress-update.js"></script>
+    <!-- <script src="js/progress-update.js"></script> -->
 
     <script>
       function openGmail() {

--- a/static/index.css
+++ b/static/index.css
@@ -10,6 +10,17 @@
     --text: #ccd0cf;
 }
 
+/* Simple fade and slide animations */
+@keyframes fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+@keyframes slideDown {
+    from { transform: translateY(-20px); opacity: 0; }
+    to { transform: translateY(0); opacity: 1; }
+}
+
 /* Example usage in your project */
 body {
     background-color: var(--obsidian);
@@ -36,6 +47,7 @@ body {
     position: relative;
     color: white; /* Text color */
     text-align: center;
+    animation: fadeIn 1.5s ease-in-out;
 }
 
 .cover::before {
@@ -58,6 +70,20 @@ body {
 
 .intro-message p{
     color: #ccc;
+}
+
+.intro-message h1{
+    font-size: 4rem;
+}
+
+@media (max-width: 600px) {
+    .intro-message h1 {
+        font-size: 2.5rem;
+    }
+
+    .intro-message p {
+        font-size: 1rem;
+    }
 }
 
 
@@ -619,6 +645,7 @@ progress::-moz-progress-bar {
     justify-content: center;
     padding: 20px;
     background-color: var(--charcoal);
+    animation: slideDown 1s ease-in-out;
 }
 
 
@@ -628,6 +655,7 @@ progress::-moz-progress-bar {
     list-style: none;
     padding: 0;
     margin: 0;
+    flex-wrap: wrap;
 }
 
 .links li {


### PR DESCRIPTION
## Summary
- hide progress section and remove its navigation link
- add fade-in/slide-down animations and responsive fonts for hero and nav

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68901cca950883298af55e4d7fab5c15