### PR TITLE
Enhance profile description and SEO metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,8 +6,13 @@
     <title>Portfolio</title>
     <meta
       name="description"
-      content="Portfolio of Seanne Cañete, an aspiring full-stack developer specializing in Django and databases."
+      content="Portfolio of Seanne Cañete, a full-stack developer skilled in Python, Django, JavaScript, React, and data analysis."
     />
+    <meta name="keywords" content="Seanne Cañete, full-stack developer, Python, Django, JavaScript, React, databases, data analysis, web development" />
+    <meta property="og:title" content="Seanne Cañete | Full-stack Developer Portfolio" />
+    <meta property="og:description" content="Portfolio of Seanne Cañete, showcasing full-stack development skills in Python, Django, JavaScript, React, and data analysis." />
+    <meta property="og:type" content="website" />
+    <meta property="og:image" content="static/profile.jpg" />
     <meta name="author" content="Seanneskie" />
     <link rel="icon" type="image/png" href="static/favicon-32x32.png" />
     <!-- Bootstrap CSS -->

--- a/sections/profile.html
+++ b/sections/profile.html
@@ -47,9 +47,7 @@
 <section id="background" data-aos="fade-right" data-aos-duration="800" data-aos-delay="100">
     <h2>Background</h2>
     <p>
-        Hello! I'm Seanne Cañete, an Information Technology undergraduate at Mindanao State University – General Santos City,
-        specializing in Databases. I'm passionate about full-stack development and currently build Django applications to
-        create efficient, user-focused solutions.
+        Hello! I'm Seanne Cañete, an Information Technology undergraduate at Mindanao State University – General Santos City with a passion for full-stack development. I specialize in databases and build intuitive, scalable web applications using Python, Django, JavaScript, React, and data analysis tools.
     </p>
     <button class="hire-me"onclick="openGmail()">Hire Me</button>
 </section>


### PR DESCRIPTION
## Summary
- expand profile summary to highlight key tech skills
- add SEO keywords and Open Graph tags for richer previews

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68902306aac883299c703481fb2563cd