### PR TITLE
Replace links with Bootstrap navbar

### DIFF
--- a/datatables.html
+++ b/datatables.html
@@ -122,15 +122,20 @@
     </style>
 
 </head>
-<body>
-    <div class="links">
-        <ul>
-            <li><a href="index.html#profile">Portfolio</a></li>
-            <li><a href="datatables.html">DataTables Demo</a></li>
-        </ul>
-
-         
-    </div>
+<body data-bs-spy="scroll" data-bs-target="#mainNav" data-bs-offset="70" tabindex="0">
+    <nav id="mainNav" class="navbar navbar-expand-lg navbar-dark" style="background-color: var(--charcoal)">
+        <div class="container-fluid">
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse justify-content-center" id="navbarNav">
+                <ul class="navbar-nav">
+                    <li class="nav-item"><a class="nav-link" href="index.html#profile">Portfolio</a></li>
+                    <li class="nav-item"><a class="nav-link active" href="datatables.html">DataTables Demo</a></li>
+                </ul>
+            </div>
+        </div>
+    </nav>
     <section id="profile">
         <div class="container mt-4 bg-dark text-white p-3">
             <div id="toggle-visibility" class="mb-3">
@@ -393,6 +398,9 @@
         });
 
     </script>
-    
+    <script>
+        const scrollSpy = new bootstrap.ScrollSpy(document.body, { target: '#mainNav', offset: 70 });
+    </script>
+
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
     <!-- Custom CSS -->
     <link href="static/index.css" rel="stylesheet" />
   </head>
-  <body style="width: 100vw; overflow-x: hidden">
+  <body data-spy="scroll" data-target="#mainNav" data-offset="70" style="width: 100vw; overflow-x: hidden">
     <div class="cover">
       <div class="intro-message" data-aos="fade-down">
         <h1>Dev Portfolio</h1>
@@ -44,18 +44,36 @@
       </div>
     </div>
 
-    <div class="links" data-aos="fade-up">
-      <ul>
-        <li><a href="#profile">Profile</a></li>
-        <li><a href="#projects">Projects</a></li>
-        <li><a href="#skills">Skills</a></li>
-        <li><a href="#certificates">Certificates</a></li>
-        <li><a href="#courses">Courses</a></li>
-        <li><a href="#achievements">Achievements</a></li>
-        <li><a href="#work-experiences">Work Experiences</a></li>
-        <!-- <li><a href="#progress">Progress</a></li> -->
-      </ul>
-    </div>
+    <nav
+      id="mainNav"
+      class="navbar navbar-expand-lg navbar-dark"
+      style="background-color: var(--charcoal)"
+      data-aos="fade-up"
+    >
+      <button
+        class="navbar-toggler"
+        type="button"
+        data-toggle="collapse"
+        data-target="#navbarNav"
+        aria-controls="navbarNav"
+        aria-expanded="false"
+        aria-label="Toggle navigation"
+      >
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse justify-content-center" id="navbarNav">
+        <ul class="navbar-nav">
+          <li class="nav-item"><a class="nav-link" href="#profile">Profile</a></li>
+          <li class="nav-item"><a class="nav-link" href="#projects">Projects</a></li>
+          <li class="nav-item"><a class="nav-link" href="#skills">Skills</a></li>
+          <li class="nav-item"><a class="nav-link" href="#certificates">Certificates</a></li>
+          <li class="nav-item"><a class="nav-link" href="#courses">Courses</a></li>
+          <li class="nav-item"><a class="nav-link" href="#achievements">Achievements</a></li>
+          <li class="nav-item"><a class="nav-link" href="#work-experiences">Work Experiences</a></li>
+          <!-- <li class="nav-item"><a class="nav-link" href="#progress">Progress</a></li> -->
+        </ul>
+      </div>
+    </nav>
 
     <!-- index.html -->
     <div id="profile"></div>
@@ -406,6 +424,9 @@
         once: true, // Whether animation should happen only once - while scrolling down
         mirror: false, // Whether elements should animate out while scrolling past them
       });
+    </script>
+    <script>
+      $('body').scrollspy({ target: '#mainNav', offset: 70 });
     </script>
     <script>
       function openCategory(evt, categoryName) {

--- a/static/index.css
+++ b/static/index.css
@@ -639,31 +639,12 @@ progress::-moz-progress-bar {
     border-radius: 10px;
 }
 
-/* Links Section */
-.links {
-    display: flex;
-    justify-content: center;
-    padding: 20px;
+/* Navbar */
+.navbar {
     background-color: var(--charcoal);
-    animation: slideDown 1s ease-in-out;
 }
 
-
-
-.links ul {
-    display: flex;
-    list-style: none;
-    padding: 0;
-    margin: 0;
-    flex-wrap: wrap;
-}
-
-.links li {
-    margin: 0 15px;
-}
-
-.links a {
-    text-decoration: none;
+.navbar-nav .nav-link {
     color: #fafafa;
     font-weight: 600;
     padding: 10px 15px;
@@ -671,24 +652,11 @@ progress::-moz-progress-bar {
     border-radius: 5px;
 }
 
-.links a:hover {
+.navbar-nav .nav-link:hover,
+.navbar-nav .nav-link.active {
     background-color: #fafafa;
     color: var(--onyx);
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
-}
-
-/* Responsive design for smaller screens */
-@media (max-width: 768px) {
-    .links ul {
-        flex-direction: column;
-        align-items: center;
-    }
-
-    .links li {
-        margin: 10px 0;
-    }
-
-    
 }
 
 


### PR DESCRIPTION
## Summary
- Swap legacy `.links` blocks for responsive Bootstrap navbars with hamburger toggler and ScrollSpy support.
- Style navigation via new CSS rules using existing color variables.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68921f846bdc8329a1f542a38867155a