### PR TITLE
Enable lazy loading for project and profile images

### DIFF
--- a/sections/profile.html
+++ b/sections/profile.html
@@ -2,7 +2,7 @@
 
     <div class="profile-container">
         <div class="profile-image">
-            <img src="static/profile.jpg" alt="Profile Picture">
+            <img src="static/profile.jpg" alt="Profile Picture" loading="lazy" width="250" height="250">
         </div>
         <div class="profile-content">
             <h2>Profile</h2>
@@ -24,22 +24,22 @@
 
     <div class="social-links">
         <a href="https://www.facebook.com/seanne.canete.7/" target="_blank">
-            <img src="static/facebook.png" alt="Facebook">
+            <img src="static/facebook.png" alt="Facebook" loading="lazy" width="48" height="48">
         </a>
         <a href="https://x.com/Seanneskie" target="_blank">
-            <img src="static/X.png" alt="Twitter">
+            <img src="static/X.png" alt="Twitter" loading="lazy" width="48" height="48">
         </a>
         <a href="https://www.linkedin.com/in/seanne-ca%C3%B1ete-8b09322a1/" target="_blank">
-            <img src="static/linkedn.png" alt="LinkedIn">
+            <img src="static/linkedn.png" alt="LinkedIn" loading="lazy" width="48" height="48">
         </a>
         <a href="https://github.com/Seanneskie" target="_blank">
-            <img src="static/github.png" alt="GitHub">
+            <img src="static/github.png" alt="GitHub" loading="lazy" width="48" height="48">
         </a>
         <a href="https://leetcode.com/u/seanneskie32/" target="_blank">
-            <img src="static/leet.png" alt="GitHub">
+            <img src="static/leet.png" alt="GitHub" loading="lazy" width="48" height="48">
         </a>
         <a href="static/canete_resume.pdf"  target="_blank" download>
-            <img src="static/pdf.png" alt="Resume">
+            <img src="static/pdf.png" alt="Resume" loading="lazy" width="48" height="48">
         </a>
     </div>
 </section>

--- a/sections/projects.html
+++ b/sections/projects.html
@@ -17,6 +17,9 @@
           src="static/ai.png"
           alt="Coin Detector Image"
           class="project-card-image"
+          loading="lazy"
+          width="350"
+          height="300"
         />
         <h5>AI Coin Detector</h5>
       </div>
@@ -59,7 +62,7 @@
     <div class="project-card">
       <!-- NoSQL project -->
       <div class="project-card-header">
-        <img src="static/Mern.png" alt="Image" class="project-card-image" />
+        <img src="static/Mern.png" alt="Image" class="project-card-image" loading="lazy" width="350" height="300" />
         <h5>NoSQL Project - MERN Stack Website</h5>
       </div>
 
@@ -98,6 +101,9 @@
           src="static/Mern.png"
           alt="CNSM Image"
           class="project-card-image"
+          loading="lazy"
+          width="350"
+          height="300"
         />
         <h5>Advance Database Project - CNSM Website</h5>
       </div>
@@ -139,6 +145,9 @@
           src="static/django.png"
           alt="Analysis Image"
           class="project-card-image"
+          loading="lazy"
+          width="350"
+          height="300"
         />
         <h5>Bitcoin Analysis App</h5>
       </div>
@@ -180,6 +189,9 @@
           src="static/python-2.png"
           alt="Desktop Payroll Management System Image"
           class="project-card-image"
+          loading="lazy"
+          width="350"
+          height="300"
         />
         <h5>Desktop Payroll Management System</h5>
       </div>
@@ -219,6 +231,9 @@
           src="static/django.png"
           alt="Coin Detector Image"
           class="project-card-image"
+          loading="lazy"
+          width="350"
+          height="300"
         />
         <h5>Digital Freelancer Profiling App</h5>
       </div>
@@ -262,6 +277,9 @@
           src="static/django.png"
           alt="Coin Detector Image"
           class="project-card-image"
+          loading="lazy"
+          width="350"
+          height="300"
         />
         <h5>CEMCDO App</h5>
       </div>
@@ -307,6 +325,9 @@
           src="static/next.png"
           alt="Coin Detector Image"
           class="project-card-image"
+          loading="lazy"
+          width="350"
+          height="300"
         />
         <h5>VIMS - Vessel Inventory Management System</h5>
       </div>
@@ -343,7 +364,7 @@
     </div>
     <div class="project-card">
       <div class="project-card-header">
-        <img src="static/php.png" alt="Laravel Itinerary Planner Image" class="project-card-image" />
+        <img src="static/php.png" alt="Laravel Itinerary Planner Image" class="project-card-image" loading="lazy" width="350" height="300" />
         <h5>Laravel Itinerary Planner</h5>
       </div>
 
@@ -370,7 +391,7 @@
 
     <div class="project-card">
       <div class="project-card-header">
-        <img src="static/django.png" alt="Albany Airbnb Dashboard Image" class="project-card-image" />
+        <img src="static/django.png" alt="Albany Airbnb Dashboard Image" class="project-card-image" loading="lazy" width="350" height="300" />
         <h5>Albany Airbnb Dashboard</h5>
       </div>
 
@@ -398,7 +419,7 @@
 
     <div class="project-card">
       <div class="project-card-header">
-        <img src="static/django.png" alt="McDonald's Sentiment Analysis Image" class="project-card-image" />
+        <img src="static/django.png" alt="McDonald's Sentiment Analysis Image" class="project-card-image" loading="lazy" width="350" height="300" />
         <h5>McDonald's Sentiment Analysis</h5>
       </div>
 
@@ -429,6 +450,9 @@
           src="static/ai.png"
           alt="AI-Powered Email Generator Image"
           class="project-card-image"
+          loading="lazy"
+          width="350"
+          height="300"
         />
         <h5>AI-Powered Email Generator</h5>
       </div>


### PR DESCRIPTION
## Summary
- lazy-load project thumbnails to defer offscreen images
- apply lazy-loading to profile picture and social icons with explicit dimensions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68921f8695c08329ab34835556ac546c