### PR TITLE
refactor: add generic asset loader

### DIFF
--- a/js/gallery.js
+++ b/js/gallery.js
@@ -20,49 +20,49 @@ function loadProjectAssets(project) {
   `;
   nav.insertAdjacentElement('afterend', section);
 
-  loadImages(project);
-  loadPDFs(project);
+  loadAssets(project, 'images', renderImages);
+  loadAssets(project, 'pdfs', renderPDFs);
 }
 
-function loadImages(project) {
-  fetch(`../static/${project}/images/images.json`)
-    .then((response) => response.json())
-    .then((images) => {
-      const container = document.querySelector('#gallery .carousel-inner');
-      if (!container) return;
-      images.forEach((file, index) => {
-        const caption = file.replace(/\.[^/.]+$/, '').replace(/[-_]/g, ' ');
-        const item = document.createElement('div');
-        item.className = `carousel-item${index === 0 ? ' active' : ''}`;
-        item.innerHTML = `
-          <img src="../static/${project}/images/${file}" class="d-block w-100" alt="${caption}">
-          <div class="carousel-caption d-none d-md-block">
-            <p>${caption}</p>
-          </div>`;
-        container.appendChild(item);
-      });
-    })
-    .catch((err) => console.error('Error loading images', err));
+async function loadAssets(project, type, handler) {
+  try {
+    const response = await fetch(`../static/${project}/${type}/${type}.json`);
+    const assets = await response.json();
+    handler(project, assets);
+  } catch (err) {
+    console.error(`Error loading ${type}`, err);
+  }
 }
 
-function loadPDFs(project) {
-  fetch(`../static/${project}/pdfs/pdfs.json`)
-    .then((response) => response.json())
-    .then((pdfs) => {
-      const list = document.getElementById('pdf-list');
-      if (!list || pdfs.length === 0) return;
-      const heading = document.createElement('h5');
-      heading.textContent = 'Downloads';
-      list.appendChild(heading);
-      const ul = document.createElement('ul');
-      ul.className = 'list-unstyled';
-      pdfs.forEach((file) => {
-        const caption = file.replace(/\.[^/.]+$/, '').replace(/[-_]/g, ' ');
-        const li = document.createElement('li');
-        li.innerHTML = `<a href="../static/${project}/pdfs/${file}" download>${caption}</a>`;
-        ul.appendChild(li);
-      });
-      list.appendChild(ul);
-    })
-    .catch((err) => console.error('Error loading PDFs', err));
+function renderImages(project, images) {
+  const container = document.querySelector('#gallery .carousel-inner');
+  if (!container) return;
+  images.forEach((file, index) => {
+    const caption = file.replace(/\.[^/.]+$/, '').replace(/[-_]/g, ' ');
+    const item = document.createElement('div');
+    item.className = `carousel-item${index === 0 ? ' active' : ''}`;
+    item.innerHTML = `
+      <img src="../static/${project}/images/${file}" class="d-block w-100" alt="${caption}">
+      <div class="carousel-caption d-none d-md-block">
+        <p>${caption}</p>
+      </div>`;
+    container.appendChild(item);
+  });
+}
+
+function renderPDFs(project, pdfs) {
+  const list = document.getElementById('pdf-list');
+  if (!list || pdfs.length === 0) return;
+  const heading = document.createElement('h5');
+  heading.textContent = 'Downloads';
+  list.appendChild(heading);
+  const ul = document.createElement('ul');
+  ul.className = 'list-unstyled';
+  pdfs.forEach((file) => {
+    const caption = file.replace(/\.[^/.]+$/, '').replace(/[-_]/g, ' ');
+    const li = document.createElement('li');
+    li.innerHTML = `<a href="../static/${project}/pdfs/${file}" download>${caption}</a>`;
+    ul.appendChild(li);
+  });
+  list.appendChild(ul);
 }


### PR DESCRIPTION
## Summary
- reuse a generic `loadAssets` for images and PDFs using async/await
- handle rendering via callbacks for images and PDFs
- call `loadAssets` from `loadProjectAssets`

## Testing
- `npm test` *(fails: could not find package.json)*


------
https://chatgpt.com/codex/tasks/task_e_689220a21ab08329964e5be0dbc5d789