### PR TITLE
Add light theme toggle with persistence

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,6 +74,7 @@
           <!-- <li class="nav-item"><a class="nav-link" href="#progress">Progress</a></li> -->
         </ul>
       </div>
+      <button id="theme-toggle" class="btn btn-outline-light ml-auto">Toggle Theme</button>
     </nav>
 
       <!-- index.html -->
@@ -439,6 +440,7 @@
 
     <!-- <script src="js/progress-tabs.js"></script> -->
     <script src="js/image-modal.js"></script>
+    <script src="js/theme-toggle.js"></script>
     <!-- <script src="js/progress-update.js"></script> -->
 
     <script>

--- a/js/theme-toggle.js
+++ b/js/theme-toggle.js
@@ -1,0 +1,20 @@
+// Handles theme toggling and persistence
+
+document.addEventListener('DOMContentLoaded', () => {
+  const toggleButton = document.getElementById('theme-toggle');
+  const body = document.body;
+  const savedTheme = localStorage.getItem('theme');
+
+  if (savedTheme === 'light') {
+    body.classList.add('light-theme');
+  }
+
+  if (toggleButton) {
+    toggleButton.addEventListener('click', () => {
+      body.classList.toggle('light-theme');
+      const theme = body.classList.contains('light-theme') ? 'light' : 'dark';
+      localStorage.setItem('theme', theme);
+    });
+  }
+});
+

--- a/static/index.css
+++ b/static/index.css
@@ -11,6 +11,16 @@
     --text: #ccd0cf;
 }
 
+/* Light theme overrides */
+.light-theme {
+    --coal: #f5f5f5;
+    --obsidian: #ffffff;
+    --onyx: #eaeaea;
+    --charcoal: #dddddd;
+    --sable: #fafafa;
+    --text: #333333;
+}
+
 /* ====================== Animations ====================== */
 @keyframes fadeIn {
     from { opacity: 0; }


### PR DESCRIPTION
## Summary
- add light-theme css variables
- add theme toggle button
- persist theme selection using localStorage

## Testing
- `npm test` (fails: package.json not found)


------
https://chatgpt.com/codex/tasks/task_e_689223cc12188329b29397aeb95e15a2