### PR TITLE
Add project filtering with search and tag controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,6 +123,9 @@
           }
 
           renderPage(currentPage);
+          const filterScript = document.createElement('script');
+          filterScript.src = 'js/project-filter.js';
+          document.body.appendChild(filterScript);
         });
       </script>
 

--- a/js/project-filter.js
+++ b/js/project-filter.js
@@ -1,0 +1,31 @@
+(function () {
+  const searchInput = document.getElementById('projectSearch');
+  const tagButtons = document.querySelectorAll('.tag-button');
+  const projectCards = document.querySelectorAll('#projectCards .project-card');
+
+  function filterProjects() {
+    const query = searchInput.value.toLowerCase();
+    const activeTagBtn = document.querySelector('.tag-button.active');
+    const activeTag = activeTagBtn ? activeTagBtn.dataset.tag.toLowerCase() : 'all';
+
+    projectCards.forEach(card => {
+      const title = card.querySelector('.project-card-header h5').textContent.toLowerCase();
+      const tags = Array.from(card.querySelectorAll('.project-tags .tag')).map(t => t.textContent.toLowerCase());
+      const matchesSearch = title.includes(query);
+      const matchesTag = activeTag === 'all' || tags.includes(activeTag);
+      card.style.display = matchesSearch && matchesTag ? 'flex' : 'none';
+    });
+  }
+
+  if (searchInput) {
+    searchInput.addEventListener('input', filterProjects);
+  }
+
+  tagButtons.forEach(btn => {
+    btn.addEventListener('click', () => {
+      tagButtons.forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      filterProjects();
+    });
+  });
+})();

--- a/sections/projects.html
+++ b/sections/projects.html
@@ -9,6 +9,20 @@
     Showcasing various web and mobile applications, built using modern
     technologies like React, Node.js, and Python.
   </p>
+  <div class="project-filters">
+    <input
+      type="text"
+      id="projectSearch"
+      placeholder="Search projects..."
+    />
+    <div class="tag-buttons">
+      <button class="tag-button active" data-tag="all">All</button>
+      <button class="tag-button" data-tag="AI">AI</button>
+      <button class="tag-button" data-tag="Django">Django</button>
+      <button class="tag-button" data-tag="ReactJS">ReactJS</button>
+      <button class="tag-button" data-tag="Python">Python</button>
+    </div>
+  </div>
   <div class="project-container" id="projectCards">
     <div class="project-card">
       <!-- AI Project -->

--- a/static/index.css
+++ b/static/index.css
@@ -151,6 +151,45 @@ p {
 
 /* ====================== Components ====================== */
 /* Project Container */
+.project-filters {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-bottom: 20px;
+}
+
+.project-filters input[type="text"] {
+    padding: 8px 12px;
+    border-radius: 5px;
+    border: 1px solid #ccc;
+    margin-bottom: 10px;
+    width: 100%;
+    max-width: 400px;
+}
+
+.tag-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    justify-content: center;
+}
+
+.tag-button {
+    background-color: var(--charcoal);
+    color: var(--text);
+    border: none;
+    padding: 6px 12px;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background-color 0.3s;
+}
+
+.tag-button.active,
+.tag-button:hover {
+    background-color: #007bff;
+    color: #fff;
+}
+
 .project-container {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));


### PR DESCRIPTION
## Summary
- Add search box and tag buttons for project filtering
- Implement filtering script for project cards
- Style filter controls and load script after projects section

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689223cc212c8329a35928fb2f3b90c6