### PR TITLE
Temporarily disable contact form

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,12 +212,8 @@
           if (typeof initTestimonials === "function") initTestimonials();
         });
 
-        // Load Contact Section
-        loadSection('contactSection', 'sections/contact.html', () => {
-          const script = document.createElement('script');
-          script.src = 'js/contact.js';
-          document.body.appendChild(script);
-        });
+        // Load Contact Section (disabled)
+        loadSection('contactSection', 'sections/contact.html');
       </script>
 
     <section

--- a/sections/contact.html
+++ b/sections/contact.html
@@ -1,6 +1,6 @@
 <section id="contact" class="container-fluid contact-section" data-aos="fade-up" data-aos-duration="800" data-aos-delay="100">
   <h2 class="mb-4" style="color: var(--text)">Contact</h2>
-  <form id="contactForm" action="https://formspree.io/f/yourFormID" method="POST" class="contact-form">
+  <form id="contactForm" action="#" method="POST" class="contact-form" onsubmit="return false;">
     <div class="form-group">
       <label for="name">Name</label>
       <input type="text" id="name" name="name" class="form-control" required />
@@ -13,7 +13,7 @@
       <label for="message">Message</label>
       <textarea id="message" name="message" rows="5" class="form-control" required></textarea>
     </div>
-    <button type="submit" class="btn btn-primary">Send</button>
-    <div id="formStatus" class="mt-3"></div>
+    <button type="submit" class="btn btn-primary" disabled>Send</button>
+    <div id="formStatus" class="mt-3 text-muted">Contact form is currently disabled.</div>
   </form>
 </section>


### PR DESCRIPTION
## Summary
- remove contact.js loading and prevent form submission to disable contact form
- show placeholder message that contact form is disabled

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892aa7e8db88329901cefcdc2fac8a3