### PR TITLE
feat: extend theme toggle to bootstrap components

### DIFF
--- a/js/section-loader.js
+++ b/js/section-loader.js
@@ -8,6 +8,10 @@ function loadSection(id, path, callback) {
         if (typeof callback === 'function') {
           callback();
         }
+        if (typeof window.applyBootstrapTheme === 'function') {
+          const savedTheme = localStorage.getItem('theme') || 'dark';
+          window.applyBootstrapTheme(savedTheme);
+        }
       }
     })
     .catch((error) => console.error(`Error loading ${path}:`, error));

--- a/js/theme-toggle.js
+++ b/js/theme-toggle.js
@@ -1,4 +1,59 @@
-// Handles theme toggling and persistence
+// Handles theme toggling, persistence, and Bootstrap component updates
+
+function applyBootstrapTheme(theme) {
+  const navbars = document.querySelectorAll('.navbar');
+  navbars.forEach((navbar) => {
+    navbar.classList.remove('navbar-light', 'navbar-dark', 'bg-light', 'bg-dark');
+    if (theme === 'light') {
+      navbar.classList.add('navbar-light', 'bg-light');
+    } else {
+      navbar.classList.add('navbar-dark', 'bg-dark');
+    }
+  });
+
+  const toggleButton = document.getElementById('theme-toggle');
+  if (toggleButton) {
+    toggleButton.classList.remove('btn-outline-light', 'btn-outline-dark');
+    toggleButton.classList.add(
+      theme === 'light' ? 'btn-outline-dark' : 'btn-outline-light',
+    );
+  }
+
+  const buttons = document.querySelectorAll('.btn');
+  buttons.forEach((btn) => {
+    if (theme === 'light') {
+      if (btn.classList.contains('btn-outline-light')) {
+        btn.classList.replace('btn-outline-light', 'btn-outline-dark');
+      }
+      if (btn.classList.contains('btn-dark')) {
+        btn.classList.replace('btn-dark', 'btn-light');
+      }
+    } else {
+      if (btn.classList.contains('btn-outline-dark')) {
+        btn.classList.replace('btn-outline-dark', 'btn-outline-light');
+      }
+      if (btn.classList.contains('btn-light')) {
+        btn.classList.replace('btn-light', 'btn-dark');
+      }
+    }
+  });
+
+  document.querySelectorAll('.bg-light, .bg-dark').forEach((el) => {
+    if (theme === 'light' && el.classList.contains('bg-dark')) {
+      el.classList.replace('bg-dark', 'bg-light');
+    } else if (theme === 'dark' && el.classList.contains('bg-light')) {
+      el.classList.replace('bg-light', 'bg-dark');
+    }
+  });
+
+  document.querySelectorAll('.text-light, .text-dark').forEach((el) => {
+    if (theme === 'light' && el.classList.contains('text-light')) {
+      el.classList.replace('text-light', 'text-dark');
+    } else if (theme === 'dark' && el.classList.contains('text-dark')) {
+      el.classList.replace('text-dark', 'text-light');
+    }
+  });
+}
 
 document.addEventListener('DOMContentLoaded', () => {
   const toggleButton = document.getElementById('theme-toggle');
@@ -9,12 +64,18 @@ document.addEventListener('DOMContentLoaded', () => {
     body.classList.add('light-theme');
   }
 
+  applyBootstrapTheme(savedTheme === 'light' ? 'light' : 'dark');
+
   if (toggleButton) {
     toggleButton.addEventListener('click', () => {
       body.classList.toggle('light-theme');
       const theme = body.classList.contains('light-theme') ? 'light' : 'dark';
       localStorage.setItem('theme', theme);
+      applyBootstrapTheme(theme);
     });
   }
 });
+
+// Expose function for dynamically loaded sections
+window.applyBootstrapTheme = applyBootstrapTheme;
 


### PR DESCRIPTION
## Summary
- enhance theme toggle to update Bootstrap classes and persist theme
- reapply chosen theme to dynamically loaded sections

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892aaaeefe483298a46ba2c504c8250