### PR TITLE
Fix unclosed brace in index.css

### DIFF
--- a/static/index.css
+++ b/static/index.css
@@ -1099,6 +1099,7 @@ progress::-moz-progress-bar {
     color: var(--text);
     padding: 1.5rem;
     border-radius: 0.5rem;
+}
 
 /* ====================== Contact Section ====================== */
 #contact {


### PR DESCRIPTION
## Summary
- close the missing curly brace in `static/index.css` for the `.testimonial-item` rule

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892ac57e12c8329990a503b97df3ff0