### PR TITLE
Add dates to work experience entries

### DIFF
--- a/assets/datafiles/work-experiences.json
+++ b/assets/datafiles/work-experiences.json
@@ -2,7 +2,7 @@
   {
     "company": "TSP Marine Industries",
     "project": "Vessel Inventory Management System (VIMS)",
-    "period": "",
+    "period": "November 2024 – June 2025",
     "tech": [
       "Next.js 15",
       "TypeScript",
@@ -22,7 +22,7 @@
   {
     "company": "CEMCDO",
     "project": "Cooperative Profiling & Fund Utilization System",
-    "period": "OJT",
+    "period": "January 2025 – April 2025",
     "tech": [
       "Django",
       "Tailwind CSS",
@@ -42,7 +42,7 @@
   {
     "company": "COTSEYE",
     "project": "Crowd mapping for Crown of Thorns (COTS) Monitoring",
-    "period": "May 2024 – Aug 2024",
+    "period": "May 2024 – August 2024",
     "tech": [
       "Django",
       "Python",

--- a/js/work-experiences.js
+++ b/js/work-experiences.js
@@ -19,6 +19,14 @@ function initWorkExperiences() {
         title.textContent = `${exp.company} – ${exp.project}`;
         header.appendChild(title);
 
+        if (exp.period) {
+          const period = document.createElement('p');
+          period.className = 'card-subtitle mb-2';
+          period.style.color = 'var(--text)';
+          period.textContent = exp.period;
+          header.appendChild(period);
+        }
+
         if (exp.tech && exp.tech.length) {
           const tech = document.createElement('p');
           tech.className = 'card-subtitle mb-2 fw-bold fst-italic';


### PR DESCRIPTION
## Summary
- display work experience date ranges on the site
- add date ranges to work experience data

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892bdc837fc8329a9b8aa74f27e4d48