### PR TITLE
Align project detail pages with shared header styling

### DIFF
--- a/project-details/ai-powered-email-generator.html
+++ b/project-details/ai-powered-email-generator.html
@@ -20,6 +20,15 @@
 
     <!-- Custom CSS -->
     <link href="../static/index.css" rel="stylesheet" />
+    <style>
+      p {
+        color: #555;
+      }
+
+      p#blogHeader {
+        color: var(--text);
+      }
+    </style>
   </head>
 
   <body
@@ -55,13 +64,13 @@
               class="img-fluid rounded shadow"
               style="max-width: 350px; height: auto"
             />
-            <div class="mt-2" style="background-color: var(--text); margin-bottom: 0">
-              <p class="lead">
+            <div class="projectHeader mt-2">
+              <p id="blogHeader" class="lead">
                 <strong>Overview:</strong><br />
                 Web app that crafts emails with adjustable tone using LangChain and
                 OpenRouter. Automatically appends personalized signatures.
               </p>
-              <p>
+              <p id="blogHeader">
                 <strong>Collaborators:</strong><br />
                 Solo Project
               </p>

--- a/project-details/albany-airbnb-dashboard.html
+++ b/project-details/albany-airbnb-dashboard.html
@@ -20,6 +20,15 @@
 
     <!-- Custom CSS -->
     <link href="../static/index.css" rel="stylesheet" />
+    <style>
+      p {
+        color: #555;
+      }
+
+      p#blogHeader {
+        color: var(--text);
+      }
+    </style>
   </head>
 
   <body
@@ -55,12 +64,12 @@
               class="img-fluid rounded shadow"
               style="max-width: 350px; height: auto"
             />
-            <div class="mt-2" style="background-color: var(--text); margin-bottom: 0">
-              <p class="lead">
+            <div class="projectHeader mt-2">
+              <p id="blogHeader" class="lead">
                 <strong>Overview:</strong><br />
                 An interactive dashboard built with HTML, CSS, and JavaScript to explore Airbnb listings in Albany, NY. It visualizes prices, availability, and guest sentiment through charts and maps.
               </p>
-              <p>
+              <p id="blogHeader">
                 <strong>Collaborators:</strong><br />
                 Solo project for ITD112 - Data Analysis and Visualization
               </p>

--- a/project-details/bitcoin-analysis-app.html
+++ b/project-details/bitcoin-analysis-app.html
@@ -20,6 +20,15 @@
 
     <!-- Custom CSS -->
     <link href="../static/index.css" rel="stylesheet" />
+    <style>
+      p {
+        color: #555;
+      }
+
+      p#blogHeader {
+        color: var(--text);
+      }
+    </style>
   </head>
 
   <body
@@ -55,12 +64,12 @@
               class="img-fluid rounded shadow"
               style="max-width: 350px; height: auto"
             />
-            <div class="mt-2" style="background-color: var(--text); margin-bottom: 0">
-              <p class="lead">
+            <div class="projectHeader mt-2">
+              <p id="blogHeader" class="lead">
                 <strong>Overview:</strong><br />
                 This is a placeholder overview for Bitcoin Analysis App.
               </p>
-              <p>
+              <p id="blogHeader">
                 <strong>Collaborators:</strong><br />
                 Placeholder Collaborators
               </p>

--- a/project-details/cemcdo-app.html
+++ b/project-details/cemcdo-app.html
@@ -20,6 +20,15 @@
 
     <!-- Custom CSS -->
     <link href="../static/index.css" rel="stylesheet" />
+    <style>
+      p {
+        color: #555;
+      }
+
+      p#blogHeader {
+        color: var(--text);
+      }
+    </style>
   </head>
 
   <body
@@ -55,14 +64,14 @@
               class="img-fluid rounded shadow"
               style="max-width: 350px; height: auto"
             />
-            <div class="mt-2" style="background-color: var(--text); margin-bottom: 0">
-              <p class="lead">
+            <div class="projectHeader mt-2">
+              <p id="blogHeader" class="lead">
                 <strong>Overview:</strong><br />
                 A comprehensive fund utilization and cooperative profiling
                 system for the City Economic Management and Cooperative
                 Development Office of General Santos City.
               </p>
-              <p>
+              <p id="blogHeader">
                 <strong>Collaborators:</strong><br />
                 Azlan Tomindug, Kimberly Baylon, Bridget Jose, Francheska
                 Besana, Seanne Cañete

--- a/project-details/cnsm-website.html
+++ b/project-details/cnsm-website.html
@@ -20,6 +20,15 @@
 
     <!-- Custom CSS -->
     <link href="../static/index.css" rel="stylesheet" />
+    <style>
+      p {
+        color: #555;
+      }
+
+      p#blogHeader {
+        color: var(--text);
+      }
+    </style>
   </head>
 
   <body
@@ -55,12 +64,12 @@
               class="img-fluid rounded shadow"
               style="max-width: 350px; height: auto"
             />
-            <div class="mt-2" style="background-color: var(--text); margin-bottom: 0">
-              <p class="lead">
+            <div class="projectHeader mt-2">
+              <p id="blogHeader" class="lead">
                 <strong>Overview:</strong><br />
                 This is a placeholder overview for Advance Database Project - CNSM Website.
               </p>
-              <p>
+              <p id="blogHeader">
                 <strong>Collaborators:</strong><br />
                 Placeholder Collaborators
               </p>

--- a/project-details/digital-freelancer-profiling-app.html
+++ b/project-details/digital-freelancer-profiling-app.html
@@ -20,6 +20,15 @@
 
     <!-- Custom CSS -->
     <link href="../static/index.css" rel="stylesheet" />
+    <style>
+      p {
+        color: #555;
+      }
+
+      p#blogHeader {
+        color: var(--text);
+      }
+    </style>
   </head>
 
   <body
@@ -55,12 +64,12 @@
               class="img-fluid rounded shadow"
               style="max-width: 350px; height: auto"
             />
-            <div class="mt-2" style="background-color: var(--text); margin-bottom: 0">
-              <p class="lead">
+            <div class="projectHeader mt-2">
+              <p id="blogHeader" class="lead">
                 <strong>Overview:</strong><br />
                 This is a placeholder overview for Digital Freelancer Profiling App.
               </p>
-              <p>
+              <p id="blogHeader">
                 <strong>Collaborators:</strong><br />
                 Placeholder Collaborators
               </p>

--- a/project-details/itinerary-planner.html
+++ b/project-details/itinerary-planner.html
@@ -20,6 +20,15 @@
 
     <!-- Custom CSS -->
     <link href="../static/index.css" rel="stylesheet" />
+    <style>
+      p {
+        color: #555;
+      }
+
+      p#blogHeader {
+        color: var(--text);
+      }
+    </style>
   </head>
 
   <body
@@ -55,12 +64,12 @@
               class="img-fluid rounded shadow"
               style="max-width: 350px; height: auto"
             />
-            <div class="mt-2" style="background-color: var(--text); margin-bottom: 0">
-              <p class="lead">
+            <div class="projectHeader mt-2">
+              <p id="blogHeader" class="lead">
                 <strong>Overview:</strong><br />
                 Laravel 12 web app for organizing trips, activities, bookings, and budgets with interactive maps and charts.
               </p>
-              <p>
+              <p id="blogHeader">
                 <strong>Collaborators:</strong><br />
                 Solo project
               </p>

--- a/project-details/mcdonalds-sentiment-analysis.html
+++ b/project-details/mcdonalds-sentiment-analysis.html
@@ -20,6 +20,15 @@
 
     <!-- Custom CSS -->
     <link href="../static/index.css" rel="stylesheet" />
+    <style>
+      p {
+        color: #555;
+      }
+
+      p#blogHeader {
+        color: var(--text);
+      }
+    </style>
   </head>
 
   <body
@@ -55,12 +64,12 @@
               class="img-fluid rounded shadow"
               style="max-width: 350px; height: auto"
             />
-            <div class="mt-2" style="background-color: var(--text); margin-bottom: 0">
-              <p class="lead">
+            <div class="projectHeader mt-2">
+              <p id="blogHeader" class="lead">
                 <strong>Overview:</strong><br />
                 This is a placeholder overview for McDonald's Sentiment Analysis.
               </p>
-              <p>
+              <p id="blogHeader">
                 <strong>Collaborators:</strong><br />
                 Placeholder Collaborators
               </p>

--- a/project-details/pms.html
+++ b/project-details/pms.html
@@ -20,6 +20,15 @@
 
     <!-- Custom CSS -->
     <link href="../static/index.css" rel="stylesheet" />
+    <style>
+      p {
+        color: #555;
+      }
+
+      p#blogHeader {
+        color: var(--text);
+      }
+    </style>
   </head>
 
   <body
@@ -55,13 +64,13 @@
               class="img-fluid rounded shadow"
               style="max-width: 350px; height: auto"
             />
-            <div class="mt-2" style="background-color: var(--text); margin-bottom: 0">
-              <p class="lead">
+            <div class="projectHeader mt-2">
+              <p id="blogHeader" class="lead">
                 <strong>Overview:</strong><br />
                 Desktop application pairing a FastAPI backend with an Electron
                 desktop shell to manage employees, payroll periods and reports.
               </p>
-              <p>
+              <p id="blogHeader">
                 <strong>Collaborators:</strong><br />
                 Solo Project
               </p>

--- a/project-details/vims.html
+++ b/project-details/vims.html
@@ -20,6 +20,15 @@
 
     <!-- Custom CSS -->
     <link href="../static/index.css" rel="stylesheet" />
+    <style>
+      p {
+        color: #555;
+      }
+
+      p#blogHeader {
+        color: var(--text);
+      }
+    </style>
   </head>
 
   <body
@@ -55,12 +64,12 @@
               class="img-fluid rounded shadow"
               style="max-width: 350px; height: auto"
             />
-            <div class="mt-2" style="background-color: var(--text); margin-bottom: 0">
-              <p class="lead">
+            <div class="projectHeader mt-2">
+              <p id="blogHeader" class="lead">
                 <strong>Overview:</strong><br />
                 This is a placeholder overview for VIMS - Vessel Inventory Management System.
               </p>
-              <p>
+              <p id="blogHeader">
                 <strong>Collaborators:</strong><br />
                 Placeholder Collaborators
               </p>


### PR DESCRIPTION
## Summary
- Replace inline-styled project headers with `projectHeader` container and `blogHeader` paragraphs
- Add local style block to ensure consistent paragraph colors across project pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894578d409883298fa14b0a29e5e25a