### PR TITLE
Standardize dark theme for project detail pages

### DIFF
--- a/project-details/ai-coin-detector.html
+++ b/project-details/ai-coin-detector.html
@@ -20,28 +20,13 @@
 
     <!-- Custom CSS -->
     <link href="../static/index.css" rel="stylesheet" />
-    <style>
-      p {
-        color: #555;
-      }
-
-      p#blogHeader {
-        color: var(--text);
-      }
-    </style>
+    <link href="../static/project-details.css" rel="stylesheet" />
   </head>
 
-  <body
-    style="
-      background-color: var(--obsidian);
-      color: var(--text);
-      font-family: 'Open Sans', sans-serif;
-    "
-  >
+  <body>
     <!-- Navigation -->
     <nav
       class="d-flex justify-content-between align-items-center p-3"
-      style="background-color: var(--sable)"
     >
       <a href="https://seanneskie.github.io/Seanne-Portfolio/" class="btn btn-light">← Go Back</a>
       <h1 class="text-white m-0">AI Coin Detector</h1>
@@ -49,9 +34,7 @@
     </nav>
 
     <!-- Project Content -->
-    <section
-      style="background-color: var(--charcoal)"
-      class="container-fluid"
+    <section class="container-fluid hero"
       data-aos="fade-up"
       data-aos-duration="800"
     >
@@ -91,7 +74,7 @@
     </section>
     <section>
       <div class="container">
-        <h2 style="color: var(--charcoal)">Introduction</h2>
+        <h2>Introduction</h2>
         <p>
           In the expanding field of artificial intelligence (AI), the creation
           of accessible, real-world applications demonstrates the rapid growth
@@ -107,7 +90,7 @@
           financial transactions and educational purposes related to currency
           recognition and management.
         </p>
-        <strong style="color: var(--charcoal)">Statement of the Problem</strong>
+        <strong>Statement of the Problem</strong>
         <p>
           The new series of Philippine peso coins are designed to be more
           identical to each other, which can be challenging for people with
@@ -116,7 +99,7 @@
           through images or video samples, thereby enhancing their accessibility
           and convenience in daily transactions (Alon et al., 2021).
         </p>
-        <strong style="color: var(--charcoal)">Significance</strong>
+        <strong>Significance</strong>
         <p>
           The significance of this project lies not only in its practical
           application but also in its educational value. It provides a realistic
@@ -134,7 +117,7 @@
         </p>
       </div>
       <div class="container">
-        <h2 style="color: var(--charcoal)">Rationale</h2>
+        <h2>Rationale</h2>
         <p>
           The rationale behind developing a Philippine coin detection AI lies in
           its potential to improve efficiency, accuracy, accessibility,
@@ -146,8 +129,8 @@
         </p>
       </div>
       <div class="container">
-        <h2 style="color: var(--charcoal)">Data Collection and Preparation</h2>
-        <strong style="color: var(--charcoal)">Data Collection</strong>
+        <h2>Data Collection and Preparation</h2>
+        <strong>Data Collection</strong>
         <p>
           The dataset used for the AI coin detection system, specifically for
           the Philippine peso, consists of legal tender coins that are accepted
@@ -175,7 +158,7 @@
           during transactions.
         </p>
         <p>Right below are the classification of the coins used as dataset:</p>
-        <ul style="color: #555">
+        <ul>
           <li>
             <p>25-Cents Coin Photos</p>
           </li>
@@ -192,7 +175,7 @@
             <p>20-Peso Coin Photos</p>
           </li>
         </ul>
-        <strong style="color: var(--charcoal)">Training and Testing</strong>
+        <strong>Training and Testing</strong>
         <p>
           The training set was composed of coins numbering at least a 100 of
           samples as long as it is possible for the group to collect. Moreover,
@@ -205,8 +188,8 @@
         </p>
       </div>
       <div class="container">
-        <h2 style="color: var(--charcoal)">Model Development</h2>
-        <strong style="color: var(--charcoal)">Architecture and Setup</strong>
+        <h2>Model Development</h2>
+        <strong>Architecture and Setup</strong>
         <p>
           The setup used for training Teachable Model was the default setup of
           teachable model. The classes in the image model were 10 and will be
@@ -302,8 +285,8 @@
         </div>
       </div>
       <div class="container">
-        <h2 style="color: var(--charcoal)">Training and Evaluation</h2>
-        <strong style="color: var(--charcoal)"
+        <h2>Training and Evaluation</h2>
+        <strong
           >Training Processes and Challenges</strong
         >
         <p>
@@ -335,7 +318,7 @@
           conditions are consistent across all images to reduce the impact of
           lighting on the model's performance.
         </p>
-        <strong style="color: var(--charcoal)">Evaluation</strong>
+        <strong>Evaluation</strong>
         <p>
           For testing the model, we used past data of the first model test to
           compare to the current model testing but only by remembering what were
@@ -358,8 +341,8 @@
         </p>
       </div>
       <div class="container">
-        <h2 style="color: var(--charcoal)">Deployment and Uses Case</h2>
-        <strong style="color: var(--charcoal)">Real World Deployment</strong>
+        <h2>Deployment and Uses Case</h2>
+        <strong>Real World Deployment</strong>
         <p>
           The "Philippine Peso Coin Detector and Counter" AI application has a
           potential for creation into a variety of real-world settings to
@@ -382,7 +365,7 @@
           procedures, providing benefits in terms of speed, accuracy, and
           cost-effectiveness (Humanness in the Age of AI, 2023).
         </p>
-        <h3 style="color: var(--charcoal)">
+        <h3>
           Potential Use Case or Application for the developed AI application
         </h3>
         <p>
@@ -394,7 +377,7 @@
           numerous industries to improve efficiency, accuracy, and ease in
           financial transactions and management.
         </p>
-        <strong style="color: var(--charcoal)"
+        <strong
           >Retail and Consumer Services</strong
         >
         <p>
@@ -414,7 +397,7 @@
           payments without manual scanning or waiting in line, thereby reducing
           wait times and improving overall efficiency (admin, 2024).
         </p>
-        <strong style="color: var(--charcoal)"
+        <strong
           >Banking and Financial Institutions</strong
         >
         <p>
@@ -434,7 +417,7 @@
           tasks such as data entry, account reconciliation, and document
           processing, leading to cost savings and greater operational efficiency
         </p>
-        <strong style="color: var(--charcoal)">Charitable Organizations</strong>
+        <strong>Charitable Organizations</strong>
         <p>
           Charitable groups that collect coins can use this AI application to
           better efficiently count and categorize donations. By automating the
@@ -454,7 +437,7 @@
         </p>
       </div>
       <div class="container">
-        <h2 style="color: var(--charcoal)">
+        <h2>
           Ethical and Societal Implications
         </h2>
         <p>
@@ -464,7 +447,7 @@
           reliability, security threats, employment displacement, and a decrease
           in errors and frauds.
         </p>
-        <strong style="color: var(--charcoal)"
+        <strong
           >Reliability and Accuracy
         </strong>
         <p>
@@ -486,7 +469,7 @@
           detection that could impact user trust and result in financial
           losses.”
         </p>
-        <strong style="color: var(--charcoal)">Job Displacement </strong>
+        <strong>Job Displacement </strong>
         <p>
           One additional aspect to take into account regarding the possible
           ethical and societal implications is the possibility of job
@@ -506,7 +489,7 @@
           roles, potentially worsening inequality if not managed carefully (The
           White House, 2022).
         </p>
-        <strong style="color: var(--charcoal)"
+        <strong
           >Banking and Financial Institutions</strong
         >
         <p>
@@ -526,7 +509,7 @@
           tasks such as data entry, account reconciliation, and document
           processing, leading to cost savings and greater operational efficiency
         </p>
-        <strong style="color: var(--charcoal)">Charitable Organizations</strong>
+        <strong>Charitable Organizations</strong>
         <p>
           Charitable groups that collect coins can use this AI application to
           better efficiently count and categorize donations. By automating the

--- a/project-details/ai-powered-email-generator.html
+++ b/project-details/ai-powered-email-generator.html
@@ -20,28 +20,13 @@
 
     <!-- Custom CSS -->
     <link href="../static/index.css" rel="stylesheet" />
-    <style>
-      p {
-        color: #555;
-      }
-
-      p#blogHeader {
-        color: var(--text);
-      }
-    </style>
+    <link href="../static/project-details.css" rel="stylesheet" />
   </head>
 
-  <body
-    style="
-      background-color: var(--obsidian);
-      color: var(--text);
-      font-family: 'Open Sans', sans-serif;
-    "
-  >
+  <body>
     <!-- Navigation -->
     <nav
       class="d-flex justify-content-between align-items-center p-3"
-      style="background-color: var(--sable)"
     >
       <a href="https://seanneskie.github.io/Seanne-Portfolio/" class="btn btn-light">← Go Back</a>
       <h1 class="text-white m-0">AI-Powered Email Generator</h1>
@@ -49,9 +34,7 @@
     </nav>
 
     <!-- Project Content -->
-    <section
-      style="background-color: var(--charcoal)"
-      class="container-fluid"
+    <section class="container-fluid hero"
       data-aos="fade-up"
       data-aos-duration="800"
     >
@@ -81,7 +64,7 @@
     </section>
     <section>
       <div class="container">
-        <h1 style="color: var(--charcoal)">Introduction</h1>
+        <h1>Introduction</h1>
         <p>
           This Django application leverages LangChain's ChatOpenAI wrapper to
           connect with models on OpenRouter. Users provide recipient details,
@@ -89,7 +72,7 @@
         </p>
       </div>
       <div class="container">
-        <h1 style="color: var(--charcoal)">Details</h1>
+        <h1>Details</h1>
         <p>
           Features include automatic signature insertion from environment
           variables, logging of generated messages, and optional sending via

--- a/project-details/albany-airbnb-dashboard.html
+++ b/project-details/albany-airbnb-dashboard.html
@@ -20,28 +20,13 @@
 
     <!-- Custom CSS -->
     <link href="../static/index.css" rel="stylesheet" />
-    <style>
-      p {
-        color: #555;
-      }
-
-      p#blogHeader {
-        color: var(--text);
-      }
-    </style>
+    <link href="../static/project-details.css" rel="stylesheet" />
   </head>
 
-  <body
-    style="
-      background-color: var(--obsidian);
-      color: var(--text);
-      font-family: 'Open Sans', sans-serif;
-    "
-  >
+  <body>
     <!-- Navigation -->
     <nav
       class="d-flex justify-content-between align-items-center p-3"
-      style="background-color: var(--sable)"
     >
       <a href="https://seanneskie.github.io/Seanne-Portfolio/" class="btn btn-light">← Go Back</a>
       <h1 class="text-white m-0">Albany Airbnb Dashboard</h1>
@@ -49,9 +34,7 @@
     </nav>
 
     <!-- Project Content -->
-    <section
-      style="background-color: var(--charcoal)"
-      class="container-fluid"
+    <section class="container-fluid hero"
       data-aos="fade-up"
       data-aos-duration="800"
     >
@@ -80,16 +63,16 @@
     </section>
     <section>
       <div class="container">
-        <h1 style="color: var(--charcoal)">Introduction</h1>
+        <h1>Introduction</h1>
         <p>Using data from InsideAirbnb, this project presents local rental trends and review sentiment in an accessible way. Users can inspect average prices, availability, and neighborhood statistics.</p>
       </div>
       <div class="container">
-        <h1 style="color: var(--charcoal)">Details</h1>
+        <h1>Details</h1>
         <p>Features include clustered maps, summary cards, radar charts, and availability calendars that let users compare listings and explore pricing differences across Albany neighborhoods.</p>
       </div>
       <div class="container">
-        <h1 style="color: var(--charcoal)">Objectives</h1>
-        <ul style="color: var(--text)">
+        <h1>Objectives</h1>
+        <ul>
           <li>Develop an interactive dashboard using the Albany Airbnb dataset.</li>
           <li>Visualize listing distribution with heatmaps and clustered maps.</li>
           <li>Display key averages through summary cards.</li>
@@ -98,8 +81,8 @@
         </ul>
       </div>
       <div class="container">
-        <h1 style="color: var(--charcoal)">Dashboard Features</h1>
-        <ul style="color: var(--text)">
+        <h1>Dashboard Features</h1>
+        <ul>
           <li><strong>Clustered Map with Popups:</strong> explore listings without clutter.</li>
           <li><strong>Interactive Icons & Legends:</strong> quickly identify property types.</li>
           <li><strong>Summary Cards:</strong> show average price, bedrooms, bathrooms and beds.</li>
@@ -109,8 +92,8 @@
         </ul>
       </div>
       <div class="container">
-        <h1 style="color: var(--charcoal)">Insights and Findings</h1>
-        <ul style="color: var(--text)">
+        <h1>Insights and Findings</h1>
+        <ul>
           <li><strong>Sentiment Analysis:</strong> guest reviews are overwhelmingly positive.</li>
           <li><strong>Price Distribution:</strong> most listings fall between $51 and $150.</li>
           <li><strong>Neighborhood Trends:</strong> some wards command higher prices than others.</li>
@@ -118,7 +101,7 @@
         </ul>
       </div>
       <div class="container">
-        <h1 style="color: var(--charcoal)">Technologies Used</h1>
+        <h1>Technologies Used</h1>
         <div class="table-responsive">
           <table class="table table-bordered table-striped">
             <thead class="thead-dark">
@@ -153,8 +136,8 @@
         </div>
       </div>
       <div class="container">
-        <h1 style="color: var(--charcoal)">Folder Structure</h1>
-        <pre style="background-color: var(--coal); color: var(--text); padding: 10px">
+        <h1>Folder Structure</h1>
+        <pre>
 albany-airbnb-dashboard/
 ├── index.html              # Main dashboard file
 ├── static/
@@ -167,15 +150,15 @@ albany-airbnb-dashboard/
         </pre>
       </div>
       <div class="container">
-        <h1 style="color: var(--charcoal)">Usage Tips</h1>
-        <ul style="color: var(--text)">
+        <h1>Usage Tips</h1>
+        <ul>
           <li>Use the clustered map to zoom in on specific neighborhoods.</li>
           <li>Hover on the radar chart to compare a property with the average.</li>
           <li>Check the calendar views to spot popular booking dates.</li>
         </ul>
       </div>
       <div class="container">
-        <h1 style="color: var(--charcoal)">Dataset Source</h1>
+        <h1>Dataset Source</h1>
         <p>
           Data is sourced from
           <a href="http://insideairbnb.com/get-the-data.html" target="_blank"
@@ -184,8 +167,8 @@ albany-airbnb-dashboard/
         </p>
       </div>
       <div class="container">
-        <h1 style="color: var(--charcoal)">How to Run</h1>
-        <ol style="color: var(--text)">
+        <h1>How to Run</h1>
+        <ol>
           <li>Clone this repository.</li>
           <li>Open <code>albany-airbnb-dashboard/index.html</code> in your browser.</li>
         </ol>

--- a/project-details/bitcoin-analysis-app.html
+++ b/project-details/bitcoin-analysis-app.html
@@ -20,28 +20,13 @@
 
     <!-- Custom CSS -->
     <link href="../static/index.css" rel="stylesheet" />
-    <style>
-      p {
-        color: #555;
-      }
-
-      p#blogHeader {
-        color: var(--text);
-      }
-    </style>
+    <link href="../static/project-details.css" rel="stylesheet" />
   </head>
 
-  <body
-    style="
-      background-color: var(--obsidian);
-      color: var(--text);
-      font-family: 'Open Sans', sans-serif;
-    "
-  >
+  <body>
     <!-- Navigation -->
     <nav
       class="d-flex justify-content-between align-items-center p-3"
-      style="background-color: var(--sable)"
     >
       <a href="https://seanneskie.github.io/Seanne-Portfolio/" class="btn btn-light">← Go Back</a>
       <h1 class="text-white m-0">Bitcoin Analysis App</h1>
@@ -49,9 +34,7 @@
     </nav>
 
     <!-- Project Content -->
-    <section
-      style="background-color: var(--charcoal)"
-      class="container-fluid"
+    <section class="container-fluid hero"
       data-aos="fade-up"
       data-aos-duration="800"
     >
@@ -80,11 +63,11 @@
     </section>
     <section>
       <div class="container">
-        <h1 style="color: var(--charcoal)">Introduction</h1>
+        <h1>Introduction</h1>
         <p>Placeholder introduction text for Bitcoin Analysis App.</p>
       </div>
       <div class="container">
-        <h1 style="color: var(--charcoal)">Details</h1>
+        <h1>Details</h1>
         <p>More details about this project will be provided soon.</p>
       </div>
     </section>

--- a/project-details/cemcdo-app.html
+++ b/project-details/cemcdo-app.html
@@ -20,28 +20,13 @@
 
     <!-- Custom CSS -->
     <link href="../static/index.css" rel="stylesheet" />
-    <style>
-      p {
-        color: #555;
-      }
-
-      p#blogHeader {
-        color: var(--text);
-      }
-    </style>
+    <link href="../static/project-details.css" rel="stylesheet" />
   </head>
 
-  <body
-    style="
-      background-color: var(--obsidian);
-      color: var(--text);
-      font-family: 'Open Sans', sans-serif;
-    "
-  >
+  <body>
     <!-- Navigation -->
     <nav
       class="d-flex justify-content-between align-items-center p-3"
-      style="background-color: var(--sable)"
     >
       <a href="https://seanneskie.github.io/Seanne-Portfolio/" class="btn btn-light">← Go Back</a>
       <h1 class="text-white m-0">CEMCDO App</h1>
@@ -49,9 +34,7 @@
     </nav>
 
     <!-- Project Content -->
-    <section
-      style="background-color: var(--charcoal)"
-      class="container-fluid"
+    <section class="container-fluid hero"
       data-aos="fade-up"
       data-aos-duration="800"
     >
@@ -83,7 +66,7 @@
     </section>
     <section>
       <div class="container">
-        <h2 style="color: var(--charcoal)">Project Overview</h2>
+        <h2>Project Overview</h2>
         <p>
           The CEMCDO web application supports cooperative databanking,
           division&ndash;level financial management and fund augmentation with
@@ -99,7 +82,7 @@
       </div>
 
       <div class="container">
-        <h2 style="color: var(--charcoal)">Core Modules</h2>
+        <h2>Core Modules</h2>
 
         <h3>Authentication &amp; User Roles</h3>
         <ul>
@@ -146,7 +129,7 @@
       </div>
 
       <div class="container">
-        <h2 style="color: var(--charcoal)">Tech Stack</h2>
+        <h2>Tech Stack</h2>
         <table class="table table-bordered">
           <tbody>
             <tr><th>Backend</th><td>Django (Python)</td></tr>
@@ -160,7 +143,7 @@
       </div>
 
       <div class="container">
-        <h2 style="color: var(--charcoal)">Directory Structure</h2>
+        <h2>Directory Structure</h2>
         <pre><code>cemcdo-app/
 ├── cemcdo/
 │   ├── templates/
@@ -174,7 +157,7 @@
       </div>
 
       <div class="container">
-        <h2 style="color: var(--charcoal)">Key Links</h2>
+        <h2>Key Links</h2>
         <p>
           Live Demo:
           <a href="https://cemcdo-demo.onrender.com" target="_blank"
@@ -184,7 +167,7 @@
       </div>
 
       <div class="container">
-        <h2 style="color: var(--charcoal)">Support</h2>
+        <h2>Support</h2>
         <ul>
           <li>seannecanete32@gmail.com</li>
           <li>azlan.tomindug@msugensan.edu.ph</li>
@@ -193,7 +176,7 @@
       </div>
 
       <div class="container">
-        <h2 style="color: var(--charcoal)">Future Improvements</h2>
+        <h2>Future Improvements</h2>
         <ul>
           <li>Add mobile responsiveness</li>
           <li>Real-time notifications with WebSockets</li>
@@ -204,7 +187,7 @@
       </div>
 
       <div class="container">
-        <h2 style="color: var(--charcoal)">Contributors</h2>
+        <h2>Contributors</h2>
         <p>Mindanao State University &ndash; General Santos IT Interns</p>
         <p>
           Azlan Tomindug, Kimberly Baylon, Bridget Jose, Francheska Besana,

--- a/project-details/cnsm-website.html
+++ b/project-details/cnsm-website.html
@@ -20,28 +20,13 @@
 
     <!-- Custom CSS -->
     <link href="../static/index.css" rel="stylesheet" />
-    <style>
-      p {
-        color: #555;
-      }
-
-      p#blogHeader {
-        color: var(--text);
-      }
-    </style>
+    <link href="../static/project-details.css" rel="stylesheet" />
   </head>
 
-  <body
-    style="
-      background-color: var(--obsidian);
-      color: var(--text);
-      font-family: 'Open Sans', sans-serif;
-    "
-  >
+  <body>
     <!-- Navigation -->
     <nav
       class="d-flex justify-content-between align-items-center p-3"
-      style="background-color: var(--sable)"
     >
       <a href="https://seanneskie.github.io/Seanne-Portfolio/" class="btn btn-light">← Go Back</a>
       <h1 class="text-white m-0">Advance Database Project - CNSM Website</h1>
@@ -49,9 +34,7 @@
     </nav>
 
     <!-- Project Content -->
-    <section
-      style="background-color: var(--charcoal)"
-      class="container-fluid"
+    <section class="container-fluid hero"
       data-aos="fade-up"
       data-aos-duration="800"
     >
@@ -80,11 +63,11 @@
     </section>
     <section>
       <div class="container">
-        <h1 style="color: var(--charcoal)">Introduction</h1>
+        <h1>Introduction</h1>
         <p>Placeholder introduction text for Advance Database Project - CNSM Website.</p>
       </div>
       <div class="container">
-        <h1 style="color: var(--charcoal)">Details</h1>
+        <h1>Details</h1>
         <p>More details about this project will be provided soon.</p>
       </div>
     </section>

--- a/project-details/digital-freelancer-profiling-app.html
+++ b/project-details/digital-freelancer-profiling-app.html
@@ -20,28 +20,13 @@
 
     <!-- Custom CSS -->
     <link href="../static/index.css" rel="stylesheet" />
-    <style>
-      p {
-        color: #555;
-      }
-
-      p#blogHeader {
-        color: var(--text);
-      }
-    </style>
+    <link href="../static/project-details.css" rel="stylesheet" />
   </head>
 
-  <body
-    style="
-      background-color: var(--obsidian);
-      color: var(--text);
-      font-family: 'Open Sans', sans-serif;
-    "
-  >
+  <body>
     <!-- Navigation -->
     <nav
       class="d-flex justify-content-between align-items-center p-3"
-      style="background-color: var(--sable)"
     >
       <a href="https://seanneskie.github.io/Seanne-Portfolio/" class="btn btn-light">← Go Back</a>
       <h1 class="text-white m-0">Digital Freelancer Profiling App</h1>
@@ -49,9 +34,7 @@
     </nav>
 
     <!-- Project Content -->
-    <section
-      style="background-color: var(--charcoal)"
-      class="container-fluid"
+    <section class="container-fluid hero"
       data-aos="fade-up"
       data-aos-duration="800"
     >
@@ -80,11 +63,11 @@
     </section>
     <section>
       <div class="container">
-        <h1 style="color: var(--charcoal)">Introduction</h1>
+        <h1>Introduction</h1>
         <p>Placeholder introduction text for Digital Freelancer Profiling App.</p>
       </div>
       <div class="container">
-        <h1 style="color: var(--charcoal)">Details</h1>
+        <h1>Details</h1>
         <p>More details about this project will be provided soon.</p>
       </div>
     </section>

--- a/project-details/itinerary-planner.html
+++ b/project-details/itinerary-planner.html
@@ -20,28 +20,13 @@
 
     <!-- Custom CSS -->
     <link href="../static/index.css" rel="stylesheet" />
-    <style>
-      p {
-        color: #555;
-      }
-
-      p#blogHeader {
-        color: var(--text);
-      }
-    </style>
+    <link href="../static/project-details.css" rel="stylesheet" />
   </head>
 
-  <body
-    style="
-      background-color: var(--obsidian);
-      color: var(--text);
-      font-family: 'Open Sans', sans-serif;
-    "
-  >
+  <body>
     <!-- Navigation -->
     <nav
       class="d-flex justify-content-between align-items-center p-3"
-      style="background-color: var(--sable)"
     >
       <a href="https://seanneskie.github.io/Seanne-Portfolio/" class="btn btn-light">← Go Back</a>
       <h1 class="text-white m-0">Laravel Itinerary Planner</h1>
@@ -49,9 +34,7 @@
     </nav>
 
     <!-- Project Content -->
-    <section
-      style="background-color: var(--charcoal)"
-      class="container-fluid"
+    <section class="container-fluid hero"
       data-aos="fade-up"
       data-aos-duration="800"
     >
@@ -80,7 +63,7 @@
     </section>
     <section>
       <div class="container">
-        <h1 style="color: var(--charcoal)">Introduction</h1>
+        <h1>Introduction</h1>
         <p>
           Itinerary Planner lets authenticated users create trips, plan daily
           activities, manage bookings and participants, and track budgets in one
@@ -89,7 +72,7 @@
         </p>
       </div>
       <div class="container">
-        <h1 style="color: var(--charcoal)">Details</h1>
+        <h1>Details</h1>
         <ul>
           <li>CRUD management for itineraries, activities, bookings, and group members.</li>
           <li>Budget entries grouped by category with Excel and PDF export options.</li>

--- a/project-details/mcdonalds-sentiment-analysis.html
+++ b/project-details/mcdonalds-sentiment-analysis.html
@@ -20,28 +20,13 @@
 
     <!-- Custom CSS -->
     <link href="../static/index.css" rel="stylesheet" />
-    <style>
-      p {
-        color: #555;
-      }
-
-      p#blogHeader {
-        color: var(--text);
-      }
-    </style>
+    <link href="../static/project-details.css" rel="stylesheet" />
   </head>
 
-  <body
-    style="
-      background-color: var(--obsidian);
-      color: var(--text);
-      font-family: 'Open Sans', sans-serif;
-    "
-  >
+  <body>
     <!-- Navigation -->
     <nav
       class="d-flex justify-content-between align-items-center p-3"
-      style="background-color: var(--sable)"
     >
       <a href="https://seanneskie.github.io/Seanne-Portfolio/" class="btn btn-light">← Go Back</a>
       <h1 class="text-white m-0">McDonald's Sentiment Analysis</h1>
@@ -49,9 +34,7 @@
     </nav>
 
     <!-- Project Content -->
-    <section
-      style="background-color: var(--charcoal)"
-      class="container-fluid"
+    <section class="container-fluid hero"
       data-aos="fade-up"
       data-aos-duration="800"
     >
@@ -80,11 +63,11 @@
     </section>
     <section>
       <div class="container">
-        <h1 style="color: var(--charcoal)">Introduction</h1>
+        <h1>Introduction</h1>
         <p>Placeholder introduction text for McDonald's Sentiment Analysis.</p>
       </div>
       <div class="container">
-        <h1 style="color: var(--charcoal)">Details</h1>
+        <h1>Details</h1>
         <p>More details about this project will be provided soon.</p>
       </div>
     </section>

--- a/project-details/nosql-project.html
+++ b/project-details/nosql-project.html
@@ -20,33 +20,13 @@
 
     <!-- Custom CSS -->
     <link href="../static/index.css" rel="stylesheet" />
-    <style>
-      p {
-        color: #555;
-      }
-
-      p#blogHeader {
-        color: var(--text);
-      }
-
-      li {
-        color: #555;
-        font-size: 1.1rem;
-      }
-    </style>
+    <link href="../static/project-details.css" rel="stylesheet" />
   </head>
 
-  <body
-    style="
-      background-color: var(--obsidian);
-      color: var(--text);
-      font-family: 'Open Sans', sans-serif;
-    "
-  >
+  <body>
     <!-- Navigation -->
     <nav
       class="d-flex justify-content-between align-items-center p-3"
-      style="background-color: var(--sable)"
     >
       <a
         href="https://seanneskie.github.io/Seanne-Portfolio/"
@@ -58,9 +38,7 @@
     </nav>
 
     <!-- Project Content -->
-    <section
-      style="background-color: var(--charcoal)"
-      class="container-fluid"
+    <section class="container-fluid hero"
       data-aos="fade-up"
       data-aos-duration="800"
     >
@@ -96,7 +74,7 @@
     </section>
     <section>
       <div class="container">
-        <h2 style="color: var(--charcoal)">Tech Stack</h2>
+        <h2>Tech Stack</h2>
         <ul>
           <li>
             <strong>Frontend:</strong> React.js with Axios and Context API for
@@ -117,7 +95,7 @@
         </ul>
       </div>
       <div class="container">
-        <h2 style="color: var(--charcoal)">Authentication Features</h2>
+        <h2>Authentication Features</h2>
         <ul>
           <li>Users authenticate via JWT (JSON Web Tokens).</li>
           <li>
@@ -128,7 +106,7 @@
         </ul>
       </div>
       <div class="container">
-        <h2 style="color: var(--charcoal)">Core Features</h2>
+        <h2>Core Features</h2>
         <ul>
           <li>
             <strong>User Registration & Login</strong><br>
@@ -153,14 +131,8 @@
         </ul>
       </div>
       <div class="container">
-        <h2 style="color: var(--charcoal)">Folder Structure</h2>
-        <pre
-          style="
-            background-color: var(--coal);
-            color: var(--text);
-            padding: 10px;
-          "
-        >
+        <h2>Folder Structure</h2>
+        <pre>
         /client (React frontend)
           └── src/
               ├── components/

--- a/project-details/pms.html
+++ b/project-details/pms.html
@@ -20,28 +20,13 @@
 
     <!-- Custom CSS -->
     <link href="../static/index.css" rel="stylesheet" />
-    <style>
-      p {
-        color: #555;
-      }
-
-      p#blogHeader {
-        color: var(--text);
-      }
-    </style>
+    <link href="../static/project-details.css" rel="stylesheet" />
   </head>
 
-  <body
-    style="
-      background-color: var(--obsidian);
-      color: var(--text);
-      font-family: 'Open Sans', sans-serif;
-    "
-  >
+  <body>
     <!-- Navigation -->
     <nav
       class="d-flex justify-content-between align-items-center p-3"
-      style="background-color: var(--sable)"
     >
       <a href="https://seanneskie.github.io/Seanne-Portfolio/" class="btn btn-light">← Go Back</a>
       <h1 class="text-white m-0">Desktop Payroll Management System</h1>
@@ -49,9 +34,7 @@
     </nav>
 
     <!-- Project Content -->
-    <section
-      style="background-color: var(--charcoal)"
-      class="container-fluid"
+    <section class="container-fluid hero"
       data-aos="fade-up"
       data-aos-duration="800"
     >
@@ -81,14 +64,14 @@
     </section>
     <section>
       <div class="container">
-        <h1 style="color: var(--charcoal)">Introduction</h1>
+        <h1>Introduction</h1>
         <p>
           A desktop payroll management system combining a Python FastAPI backend
           and an Electron-powered front end for a seamless Windows application.
         </p>
       </div>
       <div class="container">
-        <h1 style="color: var(--charcoal)">Details</h1>
+        <h1>Details</h1>
         <p>
           The backend leverages SQLite via SQLAlchemy for data models covering
           salary grades, employees, allowances, deductions and incentives.

--- a/project-details/vims.html
+++ b/project-details/vims.html
@@ -20,28 +20,13 @@
 
     <!-- Custom CSS -->
     <link href="../static/index.css" rel="stylesheet" />
-    <style>
-      p {
-        color: #555;
-      }
-
-      p#blogHeader {
-        color: var(--text);
-      }
-    </style>
+    <link href="../static/project-details.css" rel="stylesheet" />
   </head>
 
-  <body
-    style="
-      background-color: var(--obsidian);
-      color: var(--text);
-      font-family: 'Open Sans', sans-serif;
-    "
-  >
+  <body>
     <!-- Navigation -->
     <nav
       class="d-flex justify-content-between align-items-center p-3"
-      style="background-color: var(--sable)"
     >
       <a href="https://seanneskie.github.io/Seanne-Portfolio/" class="btn btn-light">← Go Back</a>
       <h1 class="text-white m-0">VIMS - Vessel Inventory Management System</h1>
@@ -49,9 +34,7 @@
     </nav>
 
     <!-- Project Content -->
-    <section
-      style="background-color: var(--charcoal)"
-      class="container-fluid"
+    <section class="container-fluid hero"
       data-aos="fade-up"
       data-aos-duration="800"
     >
@@ -80,11 +63,11 @@
     </section>
     <section>
       <div class="container">
-        <h1 style="color: var(--charcoal)">Introduction</h1>
+        <h1>Introduction</h1>
         <p>Placeholder introduction text for VIMS - Vessel Inventory Management System.</p>
       </div>
       <div class="container">
-        <h1 style="color: var(--charcoal)">Details</h1>
+        <h1>Details</h1>
         <p>More details about this project will be provided soon.</p>
       </div>
     </section>

--- a/static/project-details.css
+++ b/static/project-details.css
@@ -1,0 +1,59 @@
+/* Standardized dark theme for project detail pages */
+body {
+  background-color: var(--obsidian);
+  color: var(--text);
+  font-family: 'Open Sans', sans-serif;
+}
+
+nav {
+  background-color: var(--sable);
+}
+
+.hero {
+  background-color: var(--charcoal);
+}
+
+h1, h2, h3, h4, h5, h6 {
+  color: var(--text-hover) !important;
+}
+
+p, li, strong {
+  color: var(--text) !important;
+}
+
+ul, ol {
+  color: var(--text);
+}
+
+pre {
+  background-color: var(--coal);
+  color: var(--text);
+  padding: 10px;
+}
+
+a.btn-outline-light.btn-secondary {
+  border-color: var(--text-hover);
+  color: var(--text-hover);
+}
+
+a.btn-outline-light.btn-secondary:hover {
+  background-color: var(--text-hover);
+  color: var(--onyx);
+}
+
+footer {
+  background-color: var(--coal);
+  color: var(--text);
+}
+
+footer a {
+  color: var(--text);
+}
+
+footer a:hover {
+  color: var(--text-hover);
+}
+
+#blogHeader {
+  color: var(--text);
+}


### PR DESCRIPTION
## Summary
- Add `project-details.css` to centralize dark mode styles for project pages
- Link new stylesheet and remove inline color styles across all project detail HTML files

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68945cde3838832994a885ac8cbeb7c2