### PR TITLE
Style certificate filters with Bootstrap

### DIFF
--- a/js/certificates.js
+++ b/js/certificates.js
@@ -49,17 +49,25 @@ function initCertificates() {
   const tagSet = new Set();
   window.certificateData.forEach(c => c.skills.forEach(t => tagSet.add(t)));
 
-  // Render tag filters
+  // Render tag filters using Bootstrap form-check styling
   tagSet.forEach(tag => {
-    const label = document.createElement('label');
-    label.style.marginRight = '8px';
+    const wrapper = document.createElement('div');
+    wrapper.className = 'form-check form-check-inline';
+
     const checkbox = document.createElement('input');
     checkbox.type = 'checkbox';
     checkbox.value = tag;
-    checkbox.style.marginRight = '4px';
-    label.appendChild(checkbox);
-    label.appendChild(document.createTextNode(tag));
-    filterContainer.appendChild(label);
+    checkbox.id = `cert-filter-${tag}`;
+    checkbox.className = 'form-check-input';
+
+    const label = document.createElement('label');
+    label.className = 'form-check-label';
+    label.htmlFor = checkbox.id;
+    label.textContent = tag;
+
+    wrapper.appendChild(checkbox);
+    wrapper.appendChild(label);
+    filterContainer.appendChild(wrapper);
   });
 
   let currentPage = 1;

--- a/sections/certificates.html
+++ b/sections/certificates.html
@@ -16,7 +16,10 @@
       class="form-control"
       style="max-width: 300px; margin-bottom: 10px"
     />
-    <div id="certificateFilters" class="project-tags"></div>
+    <div
+      id="certificateFilters"
+      class="d-flex flex-wrap justify-content-center"
+    ></div>
   </div>
   <div class="certificate-grid" id="certificateCards">
     <!-- Cards will be injected by certificates.js -->

--- a/static/index.css
+++ b/static/index.css
@@ -1029,8 +1029,11 @@ progress::-moz-progress-bar {
     margin-bottom: 20px;
 }
 
-#certificateFilters label {
+#certificateFilters .form-check {
     margin-right: 8px;
+}
+
+#certificateFilters .form-check-label {
     color: var(--text);
 }
 


### PR DESCRIPTION
## Summary
- Use Bootstrap flex utilities for certificate filter container
- Render certificate tag filters as inline Bootstrap checkboxes
- Add CSS rules to style new form-check elements consistently

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689463d25ee083299f54690197149793