### PR TITLE
feat: enhance certificate filters with pill UI and clear option

### DIFF
--- a/js/certificates.js
+++ b/js/certificates.js
@@ -49,26 +49,33 @@ function initCertificates() {
   const tagSet = new Set();
   window.certificateData.forEach(c => c.skills.forEach(t => tagSet.add(t)));
 
-  // Render tag filters using Bootstrap form-check styling
+  // Render tag filters as pill-style checkboxes
   tagSet.forEach(tag => {
-    const wrapper = document.createElement('div');
-    wrapper.className = 'form-check form-check-inline';
+    const label = document.createElement('label');
+    label.className = 'filter-pill';
 
     const checkbox = document.createElement('input');
     checkbox.type = 'checkbox';
     checkbox.value = tag;
-    checkbox.id = `cert-filter-${tag}`;
-    checkbox.className = 'form-check-input';
 
-    const label = document.createElement('label');
-    label.className = 'form-check-label';
-    label.htmlFor = checkbox.id;
-    label.textContent = tag;
+    const span = document.createElement('span');
+    span.textContent = tag;
 
-    wrapper.appendChild(checkbox);
-    wrapper.appendChild(label);
-    filterContainer.appendChild(wrapper);
+    label.appendChild(checkbox);
+    label.appendChild(span);
+    filterContainer.appendChild(label);
   });
+
+  const clearBtn = document.createElement('button');
+  clearBtn.type = 'button';
+  clearBtn.className = 'clear-filters';
+  clearBtn.textContent = 'Clear';
+  clearBtn.addEventListener('click', () => {
+    filterContainer.querySelectorAll('input[type="checkbox"]').forEach(cb => cb.checked = false);
+    currentPage = 1;
+    update();
+  });
+  filterContainer.appendChild(clearBtn);
 
   let currentPage = 1;
   // Number of certificate cards displayed per page

--- a/static/index.css
+++ b/static/index.css
@@ -1029,12 +1029,40 @@ progress::-moz-progress-bar {
     margin-bottom: 20px;
 }
 
-#certificateFilters .form-check {
-    margin-right: 8px;
+#certificateFilters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
 }
 
-#certificateFilters .form-check-label {
+#certificateFilters .filter-pill {
+    display: inline-flex;
+    cursor: pointer;
+}
+
+#certificateFilters .filter-pill input {
+    display: none;
+}
+
+#certificateFilters .filter-pill span {
+    padding: 4px 12px;
+    border: 1px solid var(--text-hover);
+    border-radius: 9999px;
     color: var(--text);
+    transition: background-color 0.3s, color 0.3s;
+}
+
+#certificateFilters .filter-pill input:checked + span {
+    background-color: var(--text-hover);
+    color: var(--bg);
+}
+
+#certificateFilters .clear-filters {
+    background: none;
+    border: none;
+    color: var(--text-hover);
+    cursor: pointer;
+    padding: 4px 12px;
 }
 
 .project-tags .tag {


### PR DESCRIPTION
## Summary
- restyle certificate tag filters as pill-style checkboxes
- add clear button and flexible wrapping to filter row

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894706616848329aaf23a3749e13da1