### PR TITLE
Refactor footer into reusable component and restyle headers

### DIFF
--- a/index.html
+++ b/index.html
@@ -420,34 +420,7 @@
       </div>
     </section>
     -->
-    <footer class="footer">
-      <div class="container">
-        <div class="footer-row">
-          <div class="footer-col">
-            <h5>Quick Links</h5>
-            <ul class="footer-links">
-              <li><a href="index.html#profile">Portfolio</a></li>
-              <li><a href="datatables.html">DataTables Demo</a></li>
-            </ul>
-          </div>
-          <div class="footer-col">
-            <h5>Follow Me</h5>
-            <a href="#" class="social-link">
-              <i class="fab fa-facebook"></i> Facebook
-            </a>
-            <a href="#" class="social-link">
-              <i class="fab fa-twitter"></i> Twitter
-            </a>
-            <a href="#" class="social-link">
-              <i class="fab fa-linkedin"></i> LinkedIn
-            </a>
-          </div>
-        </div>
-        <div class="footer-copy">
-          <p>&copy; 2024 Seanneskie. All rights reserved.</p>
-        </div>
-      </div>
-    </footer>
+    <div id="footer"></div>
 
     <!-- FontAwesome for icons -->
 
@@ -465,6 +438,7 @@
         once: true, // Whether animation should happen only once - while scrolling down
         mirror: false, // Whether elements should animate out while scrolling past them
       });
+      loadSection('footer', 'sections/footer.html');
     </script>
     <script>
       $("body").scrollspy({ target: "#mainNav", offset: 70 });

--- a/project-details/ai-coin-detector.html
+++ b/project-details/ai-coin-detector.html
@@ -25,8 +25,7 @@
 
   <body>
     <!-- Navigation -->
-    <nav
-      class="d-flex justify-content-between align-items-center p-3"
+    <nav class="details-header d-flex justify-content-between align-items-center p-3"
     >
       <a href="https://seanneskie.github.io/Seanne-Portfolio/" class="btn btn-light">← Go Back</a>
       <h1 class="text-white m-0">AI Coin Detector</h1>
@@ -531,44 +530,19 @@
     </section>
     
     <!-- Footer -->
-    <footer class="footer">
-      <div class="container">
-        <div class="footer-row">
-          <div class="footer-col">
-            <h5>Quick Links</h5>
-            <ul class="footer-links">
-              <li><a href="index.html#profile">Portfolio</a></li>
-              <li><a href="datatables.html">DataTables Demo</a></li>
-            </ul>
-          </div>
-          <div class="footer-col">
-            <h5>Follow Me</h5>
-            <a href="#" class="social-link">
-              <i class="fab fa-facebook"></i> Facebook
-            </a>
-            <a href="#" class="social-link">
-              <i class="fab fa-twitter"></i> Twitter
-            </a>
-            <a href="#" class="social-link">
-              <i class="fab fa-linkedin"></i> LinkedIn
-            </a>
-          </div>
-        </div>
-        <div class="footer-copy">
-          <p>&copy; 2024 Seanneskie. All rights reserved.</p>
-        </div>
-      </div>
-    </footer>
+    <div id="footer"></div>
 
     <!-- Bootstrap JS and AOS -->
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.js"></script>
+    <script src="../js/section-loader.js"></script>
     <script src="../js/gallery.js"></script>
     <script>
       AOS.init();
       loadProjectAssets('ai-coin-detector');
+      loadSection('footer', '../sections/footer.html');
     </script>
   </body>
 </html>

--- a/project-details/ai-powered-email-generator.html
+++ b/project-details/ai-powered-email-generator.html
@@ -25,8 +25,7 @@
 
   <body>
     <!-- Navigation -->
-    <nav
-      class="d-flex justify-content-between align-items-center p-3"
+    <nav class="details-header d-flex justify-content-between align-items-center p-3"
     >
       <a href="https://seanneskie.github.io/Seanne-Portfolio/" class="btn btn-light">← Go Back</a>
       <h1 class="text-white m-0">AI-Powered Email Generator</h1>
@@ -82,44 +81,19 @@
     </section>
 
     <!-- Footer -->
-    <footer class="footer">
-      <div class="container">
-        <div class="footer-row">
-          <div class="footer-col">
-            <h5>Quick Links</h5>
-            <ul class="footer-links">
-              <li><a href="../index.html#profile">Portfolio</a></li>
-              <li><a href="../datatables.html">DataTables Demo</a></li>
-            </ul>
-          </div>
-          <div class="footer-col">
-            <h5>Follow Me</h5>
-            <a href="#" class="social-link">
-              <i class="fab fa-facebook"></i> Facebook
-            </a>
-            <a href="#" class="social-link">
-              <i class="fab fa-twitter"></i> Twitter
-            </a>
-            <a href="#" class="social-link">
-              <i class="fab fa-linkedin"></i> LinkedIn
-            </a>
-          </div>
-        </div>
-        <div class="footer-copy">
-          <p>&copy; 2024 Seanneskie. All rights reserved.</p>
-        </div>
-      </div>
-    </footer>
+    <div id="footer"></div>
 
     <!-- Bootstrap JS and AOS -->
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.js"></script>
+    <script src="../js/section-loader.js"></script>
     <script src="../js/gallery.js"></script>
     <script>
       AOS.init();
       loadProjectAssets('ai-powered-email-generator');
+      loadSection('footer', '../sections/footer.html');
     </script>
   </body>
 </html>

--- a/project-details/albany-airbnb-dashboard.html
+++ b/project-details/albany-airbnb-dashboard.html
@@ -25,8 +25,7 @@
 
   <body>
     <!-- Navigation -->
-    <nav
-      class="d-flex justify-content-between align-items-center p-3"
+    <nav class="details-header d-flex justify-content-between align-items-center p-3"
     >
       <a href="https://seanneskie.github.io/Seanne-Portfolio/" class="btn btn-light">← Go Back</a>
       <h1 class="text-white m-0">Albany Airbnb Dashboard</h1>
@@ -178,44 +177,19 @@ albany-airbnb-dashboard/
     </section>
 
     <!-- Footer -->
-    <footer class="footer">
-      <div class="container">
-        <div class="footer-row">
-          <div class="footer-col">
-            <h5>Quick Links</h5>
-            <ul class="footer-links">
-              <li><a href="../index.html#profile">Portfolio</a></li>
-              <li><a href="../datatables.html">DataTables Demo</a></li>
-            </ul>
-          </div>
-          <div class="footer-col">
-            <h5>Follow Me</h5>
-            <a href="#" class="social-link">
-              <i class="fab fa-facebook"></i> Facebook
-            </a>
-            <a href="#" class="social-link">
-              <i class="fab fa-twitter"></i> Twitter
-            </a>
-            <a href="#" class="social-link">
-              <i class="fab fa-linkedin"></i> LinkedIn
-            </a>
-          </div>
-        </div>
-        <div class="footer-copy">
-          <p>&copy; 2024 Seanneskie. All rights reserved.</p>
-        </div>
-      </div>
-    </footer>
+    <div id="footer"></div>
 
     <!-- Bootstrap JS and AOS -->
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.js"></script>
+    <script src="../js/section-loader.js"></script>
     <script src="../js/gallery.js"></script>
     <script>
       AOS.init();
       loadProjectAssets('albany-airbnb-dashboard');
+      loadSection('footer', '../sections/footer.html');
     </script>
   </body>
 </html>

--- a/project-details/bitcoin-analysis-app.html
+++ b/project-details/bitcoin-analysis-app.html
@@ -25,7 +25,7 @@
 
   <body>
     <!-- Navigation -->
-    <nav class="d-flex justify-content-between align-items-center p-3">
+    <nav class="details-header d-flex justify-content-between align-items-center p-3">
       <a
         href="https://seanneskie.github.io/Seanne-Portfolio/"
         class="btn btn-light"
@@ -184,40 +184,14 @@
     </section>
 
     <!-- Footer -->
-    <footer class="footer">
-      <div class="container">
-        <div class="footer-row">
-          <div class="footer-col">
-            <h5>Quick Links</h5>
-            <ul class="footer-links">
-              <li><a href="../index.html#profile">Portfolio</a></li>
-              <li><a href="../datatables.html">DataTables Demo</a></li>
-            </ul>
-          </div>
-          <div class="footer-col">
-            <h5>Follow Me</h5>
-            <a href="#" class="social-link">
-              <i class="fab fa-facebook"></i> Facebook
-            </a>
-            <a href="#" class="social-link">
-              <i class="fab fa-twitter"></i> Twitter
-            </a>
-            <a href="#" class="social-link">
-              <i class="fab fa-linkedin"></i> LinkedIn
-            </a>
-          </div>
-        </div>
-        <div class="footer-copy">
-          <p>&copy; 2024 Seanneskie. All rights reserved.</p>
-        </div>
-      </div>
-    </footer>
+    <div id="footer"></div>
 
     <!-- Bootstrap JS and AOS -->
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.js"></script>
+    <script src="../js/section-loader.js"></script>
     <script src="../js/gallery.js"></script>
     <script>
       AOS.init();

--- a/project-details/cemcdo-app.html
+++ b/project-details/cemcdo-app.html
@@ -25,8 +25,7 @@
 
   <body>
     <!-- Navigation -->
-    <nav
-      class="d-flex justify-content-between align-items-center p-3"
+    <nav class="details-header d-flex justify-content-between align-items-center p-3"
     >
       <a href="https://seanneskie.github.io/Seanne-Portfolio/" class="btn btn-light">← Go Back</a>
       <h1 class="text-white m-0">CEMCDO App</h1>
@@ -197,44 +196,19 @@
     </section>
 
     <!-- Footer -->
-    <footer class="footer">
-      <div class="container">
-        <div class="footer-row">
-          <div class="footer-col">
-            <h5>Quick Links</h5>
-            <ul class="footer-links">
-              <li><a href="../index.html#profile">Portfolio</a></li>
-              <li><a href="../datatables.html">DataTables Demo</a></li>
-            </ul>
-          </div>
-          <div class="footer-col">
-            <h5>Follow Me</h5>
-            <a href="#" class="social-link">
-              <i class="fab fa-facebook"></i> Facebook
-            </a>
-            <a href="#" class="social-link">
-              <i class="fab fa-twitter"></i> Twitter
-            </a>
-            <a href="#" class="social-link">
-              <i class="fab fa-linkedin"></i> LinkedIn
-            </a>
-          </div>
-        </div>
-        <div class="footer-copy">
-          <p>&copy; 2024 Seanneskie. All rights reserved.</p>
-        </div>
-      </div>
-    </footer>
+    <div id="footer"></div>
 
     <!-- Bootstrap JS and AOS -->
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.js"></script>
+    <script src="../js/section-loader.js"></script>
     <script src="../js/gallery.js"></script>
     <script>
       AOS.init();
       loadProjectAssets('cemcdo-app');
+      loadSection('footer', '../sections/footer.html');
     </script>
   </body>
 </html>

--- a/project-details/cnsm-website.html
+++ b/project-details/cnsm-website.html
@@ -25,7 +25,7 @@
 
   <body>
     <!-- Navigation -->
-    <nav class="d-flex justify-content-between align-items-center p-3">
+    <nav class="details-header d-flex justify-content-between align-items-center p-3">
       <a
         href="https://seanneskie.github.io/Seanne-Portfolio/"
         class="btn btn-light"
@@ -177,34 +177,7 @@
     </section>
 
     <!-- Footer -->
-    <footer class="footer">
-      <div class="container">
-        <div class="footer-row">
-          <div class="footer-col">
-            <h5>Quick Links</h5>
-            <ul class="footer-links">
-              <li><a href="../index.html#profile">Portfolio</a></li>
-              <li><a href="../datatables.html">DataTables Demo</a></li>
-            </ul>
-          </div>
-          <div class="footer-col">
-            <h5>Follow Me</h5>
-            <a href="#" class="social-link">
-              <i class="fab fa-facebook"></i> Facebook
-            </a>
-            <a href="#" class="social-link">
-              <i class="fab fa-twitter"></i> Twitter
-            </a>
-            <a href="#" class="social-link">
-              <i class="fab fa-linkedin"></i> LinkedIn
-            </a>
-          </div>
-        </div>
-        <div class="footer-copy">
-          <p>&copy; 2024 Seanneskie. All rights reserved.</p>
-        </div>
-      </div>
-    </footer>
+    <div id="footer"></div>
 
     <!-- Bootstrap JS and AOS -->
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
@@ -212,9 +185,11 @@
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.js"></script>
     <!-- <script src="../js/gallery.js"></script> -->
+    <script src="../js/section-loader.js"></script>
     <script>
       AOS.init();
       loadProjectAssets("cnsm-website");
+      loadSection('footer', '../sections/footer.html');
     </script>
   </body>
 </html>

--- a/project-details/digital-freelancer-profiling-app.html
+++ b/project-details/digital-freelancer-profiling-app.html
@@ -25,8 +25,7 @@
 
   <body>
     <!-- Navigation -->
-    <nav
-      class="d-flex justify-content-between align-items-center p-3"
+    <nav class="details-header d-flex justify-content-between align-items-center p-3"
     >
       <a href="https://seanneskie.github.io/Seanne-Portfolio/" class="btn btn-light">← Go Back</a>
       <h1 class="text-white m-0">Digital Freelancer Profiling App</h1>
@@ -124,44 +123,19 @@
     </section>
 
     <!-- Footer -->
-    <footer class="footer">
-      <div class="container">
-        <div class="footer-row">
-          <div class="footer-col">
-            <h5>Quick Links</h5>
-            <ul class="footer-links">
-              <li><a href="../index.html#profile">Portfolio</a></li>
-              <li><a href="../datatables.html">DataTables Demo</a></li>
-            </ul>
-          </div>
-          <div class="footer-col">
-            <h5>Follow Me</h5>
-            <a href="#" class="social-link">
-              <i class="fab fa-facebook"></i> Facebook
-            </a>
-            <a href="#" class="social-link">
-              <i class="fab fa-twitter"></i> Twitter
-            </a>
-            <a href="#" class="social-link">
-              <i class="fab fa-linkedin"></i> LinkedIn
-            </a>
-          </div>
-        </div>
-        <div class="footer-copy">
-          <p>&copy; 2024 Seanneskie. All rights reserved.</p>
-        </div>
-      </div>
-    </footer>
+    <div id="footer"></div>
 
     <!-- Bootstrap JS and AOS -->
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.js"></script>
+    <script src="../js/section-loader.js"></script>
     <script src="../js/gallery.js"></script>
     <script>
       AOS.init();
       loadProjectAssets('digital-freelancer-profiling-app');
+      loadSection('footer', '../sections/footer.html');
     </script>
   </body>
 </html>

--- a/project-details/itinerary-planner.html
+++ b/project-details/itinerary-planner.html
@@ -25,8 +25,7 @@
 
   <body>
     <!-- Navigation -->
-    <nav
-      class="d-flex justify-content-between align-items-center p-3"
+    <nav class="details-header d-flex justify-content-between align-items-center p-3"
     >
       <a href="https://seanneskie.github.io/Seanne-Portfolio/" class="btn btn-light">← Go Back</a>
       <h1 class="text-white m-0">Laravel Itinerary Planner</h1>
@@ -83,44 +82,19 @@
     </section>
 
     <!-- Footer -->
-    <footer class="footer">
-      <div class="container">
-        <div class="footer-row">
-          <div class="footer-col">
-            <h5>Quick Links</h5>
-            <ul class="footer-links">
-              <li><a href="../index.html#profile">Portfolio</a></li>
-              <li><a href="../datatables.html">DataTables Demo</a></li>
-            </ul>
-          </div>
-          <div class="footer-col">
-            <h5>Follow Me</h5>
-            <a href="#" class="social-link">
-              <i class="fab fa-facebook"></i> Facebook
-            </a>
-            <a href="#" class="social-link">
-              <i class="fab fa-twitter"></i> Twitter
-            </a>
-            <a href="#" class="social-link">
-              <i class="fab fa-linkedin"></i> LinkedIn
-            </a>
-          </div>
-        </div>
-        <div class="footer-copy">
-          <p>&copy; 2024 Seanneskie. All rights reserved.</p>
-        </div>
-      </div>
-    </footer>
+    <div id="footer"></div>
 
     <!-- Bootstrap JS and AOS -->
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.js"></script>
+    <script src="../js/section-loader.js"></script>
     <script src="../js/gallery.js"></script>
     <script>
       AOS.init();
       loadProjectAssets('itinerary-planner');
+      loadSection('footer', '../sections/footer.html');
     </script>
   </body>
 </html>

--- a/project-details/mcdonalds-sentiment-analysis.html
+++ b/project-details/mcdonalds-sentiment-analysis.html
@@ -25,8 +25,7 @@
 
   <body>
     <!-- Navigation -->
-    <nav
-      class="d-flex justify-content-between align-items-center p-3"
+    <nav class="details-header d-flex justify-content-between align-items-center p-3"
     >
       <a href="https://seanneskie.github.io/Seanne-Portfolio/" class="btn btn-light">← Go Back</a>
       <h1 class="text-white m-0">McDonald's Sentiment Analysis</h1>
@@ -73,44 +72,19 @@
     </section>
 
     <!-- Footer -->
-    <footer class="footer">
-      <div class="container">
-        <div class="footer-row">
-          <div class="footer-col">
-            <h5>Quick Links</h5>
-            <ul class="footer-links">
-              <li><a href="../index.html#profile">Portfolio</a></li>
-              <li><a href="../datatables.html">DataTables Demo</a></li>
-            </ul>
-          </div>
-          <div class="footer-col">
-            <h5>Follow Me</h5>
-            <a href="#" class="social-link">
-              <i class="fab fa-facebook"></i> Facebook
-            </a>
-            <a href="#" class="social-link">
-              <i class="fab fa-twitter"></i> Twitter
-            </a>
-            <a href="#" class="social-link">
-              <i class="fab fa-linkedin"></i> LinkedIn
-            </a>
-          </div>
-        </div>
-        <div class="footer-copy">
-          <p>&copy; 2024 Seanneskie. All rights reserved.</p>
-        </div>
-      </div>
-    </footer>
+    <div id="footer"></div>
 
     <!-- Bootstrap JS and AOS -->
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.js"></script>
+    <script src="../js/section-loader.js"></script>
     <script src="../js/gallery.js"></script>
     <script>
       AOS.init();
       loadProjectAssets('mcdonalds-sentiment-analysis');
+      loadSection('footer', '../sections/footer.html');
     </script>
   </body>
 </html>

--- a/project-details/nosql-project.html
+++ b/project-details/nosql-project.html
@@ -25,8 +25,7 @@
 
   <body>
     <!-- Navigation -->
-    <nav
-      class="d-flex justify-content-between align-items-center p-3"
+    <nav class="details-header d-flex justify-content-between align-items-center p-3"
     >
       <a
         href="https://seanneskie.github.io/Seanne-Portfolio/"
@@ -149,34 +148,7 @@
       </div>
     </section>
 
-    <footer class="footer">
-      <div class="container">
-        <div class="footer-row">
-          <div class="footer-col">
-            <h5>Quick Links</h5>
-            <ul class="footer-links">
-              <li><a href="../index.html#profile">Portfolio</a></li>
-              <li><a href="../datatables.html">DataTables Demo</a></li>
-            </ul>
-          </div>
-          <div class="footer-col">
-            <h5>Follow Me</h5>
-            <a href="#" class="social-link">
-              <i class="fab fa-facebook"></i> Facebook
-            </a>
-            <a href="#" class="social-link">
-              <i class="fab fa-twitter"></i> Twitter
-            </a>
-            <a href="#" class="social-link">
-              <i class="fab fa-linkedin"></i> LinkedIn
-            </a>
-          </div>
-        </div>
-        <div class="footer-copy">
-          <p>&copy; 2024 Seanneskie. All rights reserved.</p>
-        </div>
-      </div>
-    </footer>
+    <div id="footer"></div>
 
     <!-- Bootstrap JS and AOS -->
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
@@ -184,9 +156,11 @@
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.js"></script>
     <!-- <script src="../js/gallery.js"></script> -->
+    <script src="../js/section-loader.js"></script>
     <script>
       AOS.init();
       loadProjectAssets("nosql-project");
+      loadSection('footer', '../sections/footer.html');
     </script>
   </body>
 </html>

--- a/project-details/pms.html
+++ b/project-details/pms.html
@@ -25,7 +25,7 @@
 
   <body>
     <!-- Navigation -->
-    <nav class="d-flex justify-content-between align-items-center p-3">
+    <nav class="details-header d-flex justify-content-between align-items-center p-3">
       <a
         href="https://seanneskie.github.io/Seanne-Portfolio/"
         class="btn btn-light"
@@ -162,40 +162,14 @@
     </section>
 
     <!-- Footer -->
-    <footer class="footer">
-      <div class="container">
-        <div class="footer-row">
-          <div class="footer-col">
-            <h5>Quick Links</h5>
-            <ul class="footer-links">
-              <li><a href="../index.html#profile">Portfolio</a></li>
-              <li><a href="../datatables.html">DataTables Demo</a></li>
-            </ul>
-          </div>
-          <div class="footer-col">
-            <h5>Follow Me</h5>
-            <a href="#" class="social-link">
-              <i class="fab fa-facebook"></i> Facebook
-            </a>
-            <a href="#" class="social-link">
-              <i class="fab fa-twitter"></i> Twitter
-            </a>
-            <a href="#" class="social-link">
-              <i class="fab fa-linkedin"></i> LinkedIn
-            </a>
-          </div>
-        </div>
-        <div class="footer-copy">
-          <p>&copy; 2024 Seanneskie. All rights reserved.</p>
-        </div>
-      </div>
-    </footer>
+    <div id="footer"></div>
 
     <!-- Bootstrap JS and AOS -->
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.js"></script>
+    <script src="../js/section-loader.js"></script>
     <script src="../js/gallery.js"></script>
     <script>
       AOS.init();

--- a/project-details/vims.html
+++ b/project-details/vims.html
@@ -25,8 +25,7 @@
 
   <body>
     <!-- Navigation -->
-    <nav
-      class="d-flex justify-content-between align-items-center p-3"
+    <nav class="details-header d-flex justify-content-between align-items-center p-3"
     >
       <a href="https://seanneskie.github.io/Seanne-Portfolio/" class="btn btn-light">← Go Back</a>
       <h1 class="text-white m-0">VIMS - Vessel Inventory Management System</h1>
@@ -73,44 +72,19 @@
     </section>
 
     <!-- Footer -->
-    <footer class="footer">
-      <div class="container">
-        <div class="footer-row">
-          <div class="footer-col">
-            <h5>Quick Links</h5>
-            <ul class="footer-links">
-              <li><a href="../index.html#profile">Portfolio</a></li>
-              <li><a href="../datatables.html">DataTables Demo</a></li>
-            </ul>
-          </div>
-          <div class="footer-col">
-            <h5>Follow Me</h5>
-            <a href="#" class="social-link">
-              <i class="fab fa-facebook"></i> Facebook
-            </a>
-            <a href="#" class="social-link">
-              <i class="fab fa-twitter"></i> Twitter
-            </a>
-            <a href="#" class="social-link">
-              <i class="fab fa-linkedin"></i> LinkedIn
-            </a>
-          </div>
-        </div>
-        <div class="footer-copy">
-          <p>&copy; 2024 Seanneskie. All rights reserved.</p>
-        </div>
-      </div>
-    </footer>
+    <div id="footer"></div>
 
     <!-- Bootstrap JS and AOS -->
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.js"></script>
+    <script src="../js/section-loader.js"></script>
     <script src="../js/gallery.js"></script>
     <script>
       AOS.init();
       loadProjectAssets('vims');
+      loadSection('footer', '../sections/footer.html');
     </script>
   </body>
 </html>

--- a/sections/footer.html
+++ b/sections/footer.html
@@ -1,0 +1,22 @@
+<footer class="footer">
+  <div class="container">
+    <div class="footer-row">
+      <div class="footer-col">
+        <h5>Quick Links</h5>
+        <ul class="footer-links">
+          <li><a href="https://seanneskie.github.io/Seanne-Portfolio/#profile">Portfolio</a></li>
+          <li><a href="https://seanneskie.github.io/Seanne-Portfolio/datatables.html">DataTables Demo</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <h5>Follow Me</h5>
+        <a href="#" class="social-link"><i class="fab fa-facebook"></i> Facebook</a>
+        <a href="#" class="social-link"><i class="fab fa-twitter"></i> Twitter</a>
+        <a href="#" class="social-link"><i class="fab fa-linkedin"></i> LinkedIn</a>
+      </div>
+    </div>
+    <div class="footer-copy">
+      <p>&copy; 2024 Seanneskie. All rights reserved.</p>
+    </div>
+  </div>
+</footer>

--- a/static/project-details.css
+++ b/static/project-details.css
@@ -5,8 +5,20 @@ body {
   font-family: 'Open Sans', sans-serif;
 }
 
-nav {
+nav.details-header {
   background-color: var(--sable);
+  color: var(--text);
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.5);
+}
+
+nav.details-header a,
+nav.details-header h1 {
+  color: var(--text);
+}
+
+nav.details-header a:hover {
+  color: var(--text-hover);
+  text-decoration: none;
 }
 
 .hero {


### PR DESCRIPTION
## Summary
- Polish project-detail headers with a new `details-header` style for improved contrast and depth
- Extract repeated footer markup into a shared `sections/footer.html` partial and load it dynamically across pages

## Testing
- `npm test` (fails: Could not read package.json)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68949f7591ec8329be9cf7481a2cd056