### PR TITLE
Use shared Bootstrap navbar on project detail pages

### DIFF
--- a/project-details/ai-coin-detector.html
+++ b/project-details/ai-coin-detector.html
@@ -7,10 +7,7 @@
     <title>AI Coin Detector - Project Details</title>
 
     <!-- Bootstrap CSS -->
-    <link
-      href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css"
-      rel="stylesheet"
-    />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
 
     <!-- AOS Animation CSS -->
     <link
@@ -25,12 +22,7 @@
 
   <body>
     <!-- Navigation -->
-    <nav class="details-header d-flex justify-content-between align-items-center p-3"
-    >
-      <a href="https://seanneskie.github.io/Seanne-Portfolio/" class="btn btn-light">← Go Back</a>
-      <h1 class="text-white m-0">AI Coin Detector</h1>
-      <span></span>
-    </nav>
+    <div id="details-header"></div>
 
     <!-- Project Content -->
     <section class="container-fluid hero"
@@ -533,14 +525,15 @@
     <div id="footer"></div>
 
     <!-- Bootstrap JS and AOS -->
-    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.js"></script>
     <script src="../js/section-loader.js"></script>
     <script src="../js/gallery.js"></script>
     <script>
       AOS.init();
+      loadSection('details-header', '../sections/details-header.html', () => {
+        document.getElementById('project-title').textContent = 'AI Coin Detector';
+      });
       loadProjectAssets('ai-coin-detector');
       loadSection('footer', '../sections/footer.html');
     </script>

--- a/project-details/ai-powered-email-generator.html
+++ b/project-details/ai-powered-email-generator.html
@@ -7,10 +7,7 @@
     <title>AI-Powered Email Generator - Project Details</title>
 
     <!-- Bootstrap CSS -->
-    <link
-      href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css"
-      rel="stylesheet"
-    />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
 
     <!-- AOS Animation CSS -->
     <link
@@ -25,12 +22,7 @@
 
   <body>
     <!-- Navigation -->
-    <nav class="details-header d-flex justify-content-between align-items-center p-3"
-    >
-      <a href="https://seanneskie.github.io/Seanne-Portfolio/" class="btn btn-light">← Go Back</a>
-      <h1 class="text-white m-0">AI-Powered Email Generator</h1>
-      <span></span>
-    </nav>
+    <div id="details-header"></div>
 
     <!-- Project Content -->
     <section class="container-fluid hero"
@@ -84,14 +76,15 @@
     <div id="footer"></div>
 
     <!-- Bootstrap JS and AOS -->
-    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.js"></script>
     <script src="../js/section-loader.js"></script>
     <script src="../js/gallery.js"></script>
     <script>
       AOS.init();
+      loadSection('details-header', '../sections/details-header.html', () => {
+        document.getElementById('project-title').textContent = 'AI-Powered Email Generator';
+      });
       loadProjectAssets('ai-powered-email-generator');
       loadSection('footer', '../sections/footer.html');
     </script>

--- a/project-details/albany-airbnb-dashboard.html
+++ b/project-details/albany-airbnb-dashboard.html
@@ -7,10 +7,7 @@
     <title>Albany Airbnb Dashboard - Project Details</title>
 
     <!-- Bootstrap CSS -->
-    <link
-      href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css"
-      rel="stylesheet"
-    />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
 
     <!-- AOS Animation CSS -->
     <link
@@ -25,12 +22,7 @@
 
   <body>
     <!-- Navigation -->
-    <nav class="details-header d-flex justify-content-between align-items-center p-3"
-    >
-      <a href="https://seanneskie.github.io/Seanne-Portfolio/" class="btn btn-light">← Go Back</a>
-      <h1 class="text-white m-0">Albany Airbnb Dashboard</h1>
-      <span></span>
-    </nav>
+    <div id="details-header"></div>
 
     <!-- Project Content -->
     <section class="container-fluid hero"
@@ -180,14 +172,15 @@ albany-airbnb-dashboard/
     <div id="footer"></div>
 
     <!-- Bootstrap JS and AOS -->
-    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.js"></script>
     <script src="../js/section-loader.js"></script>
     <script src="../js/gallery.js"></script>
     <script>
       AOS.init();
+      loadSection('details-header', '../sections/details-header.html', () => {
+        document.getElementById('project-title').textContent = 'Albany Airbnb Dashboard';
+      });
       loadProjectAssets('albany-airbnb-dashboard');
       loadSection('footer', '../sections/footer.html');
     </script>

--- a/project-details/bitcoin-analysis-app.html
+++ b/project-details/bitcoin-analysis-app.html
@@ -7,10 +7,7 @@
     <title>Bitcoin Analysis App - Project Details</title>
 
     <!-- Bootstrap CSS -->
-    <link
-      href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css"
-      rel="stylesheet"
-    />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
 
     <!-- AOS Animation CSS -->
     <link
@@ -25,15 +22,7 @@
 
   <body>
     <!-- Navigation -->
-    <nav class="details-header d-flex justify-content-between align-items-center p-3">
-      <a
-        href="https://seanneskie.github.io/Seanne-Portfolio/"
-        class="btn btn-light"
-        >← Go Back</a
-      >
-      <h1 class="text-white m-0">Bitcoin Analysis App</h1>
-      <span></span>
-    </nav>
+    <div id="details-header"></div>
 
     <!-- Project Content -->
     <section
@@ -187,15 +176,17 @@
     <div id="footer"></div>
 
     <!-- Bootstrap JS and AOS -->
-    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.js"></script>
     <script src="../js/section-loader.js"></script>
     <script src="../js/gallery.js"></script>
     <script>
       AOS.init();
+      loadSection('details-header', '../sections/details-header.html', () => {
+        document.getElementById('project-title').textContent = 'Bitcoin Analysis App';
+      });
       loadProjectAssets("bitcoin-analysis-app");
+      loadSection('footer', '../sections/footer.html');
     </script>
   </body>
 </html>

--- a/project-details/cemcdo-app.html
+++ b/project-details/cemcdo-app.html
@@ -7,10 +7,7 @@
     <title>CEMCDO App - Project Details</title>
 
     <!-- Bootstrap CSS -->
-    <link
-      href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css"
-      rel="stylesheet"
-    />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
 
     <!-- AOS Animation CSS -->
     <link
@@ -25,12 +22,7 @@
 
   <body>
     <!-- Navigation -->
-    <nav class="details-header d-flex justify-content-between align-items-center p-3"
-    >
-      <a href="https://seanneskie.github.io/Seanne-Portfolio/" class="btn btn-light">← Go Back</a>
-      <h1 class="text-white m-0">CEMCDO App</h1>
-      <span></span>
-    </nav>
+    <div id="details-header"></div>
 
     <!-- Project Content -->
     <section class="container-fluid hero"
@@ -199,14 +191,15 @@
     <div id="footer"></div>
 
     <!-- Bootstrap JS and AOS -->
-    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.js"></script>
     <script src="../js/section-loader.js"></script>
     <script src="../js/gallery.js"></script>
     <script>
       AOS.init();
+      loadSection('details-header', '../sections/details-header.html', () => {
+        document.getElementById('project-title').textContent = 'CEMCDO App';
+      });
       loadProjectAssets('cemcdo-app');
       loadSection('footer', '../sections/footer.html');
     </script>

--- a/project-details/cnsm-website.html
+++ b/project-details/cnsm-website.html
@@ -7,10 +7,7 @@
     <title>Advance Database Project - CNSM Website - Project Details</title>
 
     <!-- Bootstrap CSS -->
-    <link
-      href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css"
-      rel="stylesheet"
-    />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
 
     <!-- AOS Animation CSS -->
     <link
@@ -25,15 +22,7 @@
 
   <body>
     <!-- Navigation -->
-    <nav class="details-header d-flex justify-content-between align-items-center p-3">
-      <a
-        href="https://seanneskie.github.io/Seanne-Portfolio/"
-        class="btn btn-light"
-        >← Go Back</a
-      >
-      <h1 class="text-white m-0">Advance Database Project - CNSM Website</h1>
-      <span></span>
-    </nav>
+    <div id="details-header"></div>
 
     <!-- Project Content -->
     <section
@@ -180,14 +169,15 @@
     <div id="footer"></div>
 
     <!-- Bootstrap JS and AOS -->
-    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.js"></script>
     <!-- <script src="../js/gallery.js"></script> -->
     <script src="../js/section-loader.js"></script>
     <script>
       AOS.init();
+      loadSection('details-header', '../sections/details-header.html', () => {
+        document.getElementById('project-title').textContent = 'Advance Database Project - CNSM Website';
+      });
       loadProjectAssets("cnsm-website");
       loadSection('footer', '../sections/footer.html');
     </script>

--- a/project-details/digital-freelancer-profiling-app.html
+++ b/project-details/digital-freelancer-profiling-app.html
@@ -7,10 +7,7 @@
     <title>Digital Freelancer Profiling App - Project Details</title>
 
     <!-- Bootstrap CSS -->
-    <link
-      href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css"
-      rel="stylesheet"
-    />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
 
     <!-- AOS Animation CSS -->
     <link
@@ -25,12 +22,7 @@
 
   <body>
     <!-- Navigation -->
-    <nav class="details-header d-flex justify-content-between align-items-center p-3"
-    >
-      <a href="https://seanneskie.github.io/Seanne-Portfolio/" class="btn btn-light">← Go Back</a>
-      <h1 class="text-white m-0">Digital Freelancer Profiling App</h1>
-      <span></span>
-    </nav>
+    <div id="details-header"></div>
 
     <!-- Project Content -->
     <section class="container-fluid hero"
@@ -126,14 +118,15 @@
     <div id="footer"></div>
 
     <!-- Bootstrap JS and AOS -->
-    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.js"></script>
     <script src="../js/section-loader.js"></script>
     <script src="../js/gallery.js"></script>
     <script>
       AOS.init();
+      loadSection('details-header', '../sections/details-header.html', () => {
+        document.getElementById('project-title').textContent = 'Digital Freelancer Profiling App';
+      });
       loadProjectAssets('digital-freelancer-profiling-app');
       loadSection('footer', '../sections/footer.html');
     </script>

--- a/project-details/itinerary-planner.html
+++ b/project-details/itinerary-planner.html
@@ -7,10 +7,7 @@
     <title>Laravel Itinerary Planner - Project Details</title>
 
     <!-- Bootstrap CSS -->
-    <link
-      href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css"
-      rel="stylesheet"
-    />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
 
     <!-- AOS Animation CSS -->
     <link
@@ -25,12 +22,7 @@
 
   <body>
     <!-- Navigation -->
-    <nav class="details-header d-flex justify-content-between align-items-center p-3"
-    >
-      <a href="https://seanneskie.github.io/Seanne-Portfolio/" class="btn btn-light">← Go Back</a>
-      <h1 class="text-white m-0">Laravel Itinerary Planner</h1>
-      <span></span>
-    </nav>
+    <div id="details-header"></div>
 
     <!-- Project Content -->
     <section class="container-fluid hero"
@@ -85,14 +77,15 @@
     <div id="footer"></div>
 
     <!-- Bootstrap JS and AOS -->
-    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.js"></script>
     <script src="../js/section-loader.js"></script>
     <script src="../js/gallery.js"></script>
     <script>
       AOS.init();
+      loadSection('details-header', '../sections/details-header.html', () => {
+        document.getElementById('project-title').textContent = 'Laravel Itinerary Planner';
+      });
       loadProjectAssets('itinerary-planner');
       loadSection('footer', '../sections/footer.html');
     </script>

--- a/project-details/mcdonalds-sentiment-analysis.html
+++ b/project-details/mcdonalds-sentiment-analysis.html
@@ -7,10 +7,7 @@
     <title>McDonald's Sentiment Analysis - Project Details</title>
 
     <!-- Bootstrap CSS -->
-    <link
-      href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css"
-      rel="stylesheet"
-    />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
 
     <!-- AOS Animation CSS -->
     <link
@@ -25,12 +22,7 @@
 
   <body>
     <!-- Navigation -->
-    <nav class="details-header d-flex justify-content-between align-items-center p-3"
-    >
-      <a href="https://seanneskie.github.io/Seanne-Portfolio/" class="btn btn-light">← Go Back</a>
-      <h1 class="text-white m-0">McDonald's Sentiment Analysis</h1>
-      <span></span>
-    </nav>
+    <div id="details-header"></div>
 
     <!-- Project Content -->
     <section class="container-fluid hero"
@@ -75,14 +67,15 @@
     <div id="footer"></div>
 
     <!-- Bootstrap JS and AOS -->
-    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.js"></script>
     <script src="../js/section-loader.js"></script>
     <script src="../js/gallery.js"></script>
     <script>
       AOS.init();
+      loadSection('details-header', '../sections/details-header.html', () => {
+        document.getElementById('project-title').textContent = 'McDonald\'s Sentiment Analysis';
+      });
       loadProjectAssets('mcdonalds-sentiment-analysis');
       loadSection('footer', '../sections/footer.html');
     </script>

--- a/project-details/nosql-project.html
+++ b/project-details/nosql-project.html
@@ -7,10 +7,7 @@
     <title>NoSQL Project - MERN Stack Website - Project Details</title>
 
     <!-- Bootstrap CSS -->
-    <link
-      href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css"
-      rel="stylesheet"
-    />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
 
     <!-- AOS Animation CSS -->
     <link
@@ -25,16 +22,7 @@
 
   <body>
     <!-- Navigation -->
-    <nav class="details-header d-flex justify-content-between align-items-center p-3"
-    >
-      <a
-        href="https://seanneskie.github.io/Seanne-Portfolio/"
-        class="btn btn-light"
-        >← Go Back</a
-      >
-      <h1 class="text-white m-0">NoSQL Project - MERN Stack Website</h1>
-      <span></span>
-    </nav>
+    <div id="details-header"></div>
 
     <!-- Project Content -->
     <section class="container-fluid hero"
@@ -151,14 +139,15 @@
     <div id="footer"></div>
 
     <!-- Bootstrap JS and AOS -->
-    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.js"></script>
     <!-- <script src="../js/gallery.js"></script> -->
     <script src="../js/section-loader.js"></script>
     <script>
       AOS.init();
+      loadSection('details-header', '../sections/details-header.html', () => {
+        document.getElementById('project-title').textContent = 'NoSQL Project - MERN Stack Website';
+      });
       loadProjectAssets("nosql-project");
       loadSection('footer', '../sections/footer.html');
     </script>

--- a/project-details/pms.html
+++ b/project-details/pms.html
@@ -7,10 +7,7 @@
     <title>Desktop Payroll Management System - Project Details</title>
 
     <!-- Bootstrap CSS -->
-    <link
-      href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css"
-      rel="stylesheet"
-    />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
 
     <!-- AOS Animation CSS -->
     <link
@@ -25,15 +22,7 @@
 
   <body>
     <!-- Navigation -->
-    <nav class="details-header d-flex justify-content-between align-items-center p-3">
-      <a
-        href="https://seanneskie.github.io/Seanne-Portfolio/"
-        class="btn btn-light"
-        >← Go Back</a
-      >
-      <h1 class="text-white m-0">Desktop Payroll Management System</h1>
-      <span></span>
-    </nav>
+    <div id="details-header"></div>
 
     <!-- Project Content -->
     <section
@@ -165,15 +154,17 @@
     <div id="footer"></div>
 
     <!-- Bootstrap JS and AOS -->
-    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.js"></script>
     <script src="../js/section-loader.js"></script>
     <script src="../js/gallery.js"></script>
     <script>
       AOS.init();
+      loadSection('details-header', '../sections/details-header.html', () => {
+        document.getElementById('project-title').textContent = 'Desktop Payroll Management System';
+      });
       loadProjectAssets("pms");
+      loadSection('footer', '../sections/footer.html');
     </script>
   </body>
 </html>

--- a/project-details/vims.html
+++ b/project-details/vims.html
@@ -7,10 +7,7 @@
     <title>VIMS - Vessel Inventory Management System - Project Details</title>
 
     <!-- Bootstrap CSS -->
-    <link
-      href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css"
-      rel="stylesheet"
-    />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
 
     <!-- AOS Animation CSS -->
     <link
@@ -25,12 +22,7 @@
 
   <body>
     <!-- Navigation -->
-    <nav class="details-header d-flex justify-content-between align-items-center p-3"
-    >
-      <a href="https://seanneskie.github.io/Seanne-Portfolio/" class="btn btn-light">← Go Back</a>
-      <h1 class="text-white m-0">VIMS - Vessel Inventory Management System</h1>
-      <span></span>
-    </nav>
+    <div id="details-header"></div>
 
     <!-- Project Content -->
     <section class="container-fluid hero"
@@ -75,14 +67,15 @@
     <div id="footer"></div>
 
     <!-- Bootstrap JS and AOS -->
-    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.js"></script>
     <script src="../js/section-loader.js"></script>
     <script src="../js/gallery.js"></script>
     <script>
       AOS.init();
+      loadSection('details-header', '../sections/details-header.html', () => {
+        document.getElementById('project-title').textContent = 'VIMS - Vessel Inventory Management System';
+      });
       loadProjectAssets('vims');
       loadSection('footer', '../sections/footer.html');
     </script>

--- a/sections/details-header.html
+++ b/sections/details-header.html
@@ -1,0 +1,10 @@
+<nav class="navbar navbar-dark bg-dark navbar-expand-md">
+  <div class="container-fluid">
+    <a href="https://seanneskie.github.io/Seanne-Portfolio/" class="btn btn-light me-2">&larr; Back</a>
+    <a class="navbar-brand" id="project-title" href="#"></a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav"></div>
+  </div>
+</nav>

--- a/static/project-details.css
+++ b/static/project-details.css
@@ -5,21 +5,7 @@ body {
   font-family: 'Open Sans', sans-serif;
 }
 
-nav.details-header {
-  background-color: var(--sable);
-  color: var(--text);
-  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.5);
-}
 
-nav.details-header a,
-nav.details-header h1 {
-  color: var(--text);
-}
-
-nav.details-header a:hover {
-  color: var(--text-hover);
-  text-decoration: none;
-}
 
 .hero {
   background-color: var(--charcoal);


### PR DESCRIPTION
## Summary
- Replace custom detail headers with a reusable Bootstrap 5 navbar snippet
- Load each project's title into the shared header via `section-loader.js`
- Clean up `project-details.css` by removing redundant header styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689568ee44488329b4bde7b228d75847