### PR TITLE
fix: ensure gallery waits for header

### DIFF
--- a/js/gallery.js
+++ b/js/gallery.js
@@ -1,5 +1,5 @@
 async function loadProjectAssets(project) {
-  const nav = document.querySelector('nav');
+  const nav = await waitForNav();
   if (!nav) return;
 
   const [images, pdfs] = await Promise.all([
@@ -19,6 +19,24 @@ async function loadProjectAssets(project) {
   if (pdfList) section.appendChild(pdfList);
 
   nav.insertAdjacentElement('afterend', section);
+}
+
+function waitForNav() {
+  return new Promise((resolve) => {
+    const nav = document.querySelector('nav');
+    if (nav) {
+      resolve(nav);
+      return;
+    }
+    const observer = new MutationObserver(() => {
+      const nav = document.querySelector('nav');
+      if (nav) {
+        observer.disconnect();
+        resolve(nav);
+      }
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+  });
 }
 
 async function fetchAssets(project, type) {


### PR DESCRIPTION
## Summary
- wait for the navigation element to load before rendering project galleries
- dynamically observe DOM mutations to find the header

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689570272e2083299f41bba0bd2341be