### PR TITLE
Inline static sections and simplify footer loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,20 +6,16 @@
     <title>Portfolio</title>
     <meta
       name="description"
-      content="Portfolio of Seanne Cañete, a full-stack developer skilled in Python, Django, JavaScript, React, and data analysis."
-    />
+      content="Portfolio of Seanne Cañete, a full-stack developer skilled in Python, Django, JavaScript, React, and data analysis." />
     <meta
       name="keywords"
-      content="Seanne Cañete, full-stack developer, Python, Django, JavaScript, React, databases, data analysis, web development"
-    />
+      content="Seanne Cañete, full-stack developer, Python, Django, JavaScript, React, databases, data analysis, web development" />
     <meta
       property="og:title"
-      content="Seanne Cañete | Full-stack Developer Portfolio"
-    />
+      content="Seanne Cañete | Full-stack Developer Portfolio" />
     <meta
       property="og:description"
-      content="Portfolio of Seanne Cañete, showcasing full-stack development skills in Python, Django, JavaScript, React, and data analysis."
-    />
+      content="Portfolio of Seanne Cañete, showcasing full-stack development skills in Python, Django, JavaScript, React, and data analysis." />
     <meta property="og:type" content="website" />
     <meta property="og:image" content="static/profile.jpg" />
     <meta name="author" content="Seanneskie" />
@@ -27,24 +23,20 @@
     <!-- Bootstrap CSS -->
     <link
       href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css"
-      rel="stylesheet"
-    />
-
+      rel="stylesheet" />
     <!-- Animation Scripts -->
     <link
       rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.css"
-    />
-
+      href="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.css" />
     <!-- FontAwesome Icons -->
     <link
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css"
-      rel="stylesheet"
-    />
-
+      rel="stylesheet" />
     <!-- Custom CSS -->
     <link href="static/index.css" rel="stylesheet" />
-    <script src="js/section-loader.js"></script>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/devicon.min.css" />
   </head>
   <body style="width: 100vw; overflow-x: hidden">
     <div class="cover">
@@ -58,8 +50,7 @@
       id="mainNav"
       class="navbar navbar-expand-lg navbar-dark"
       style="background-color: var(--charcoal)"
-      data-aos="fade-up"
-    >
+      data-aos="fade-up">
       <button
         class="navbar-toggler"
         type="button"
@@ -67,40 +58,22 @@
         data-target="#navbarNav"
         aria-controls="navbarNav"
         aria-expanded="false"
-        aria-label="Toggle navigation"
-      >
+        aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
       <div
         class="collapse navbar-collapse justify-content-center"
-        id="navbarNav"
-      >
+        id="navbarNav">
         <ul class="navbar-nav">
-          <li class="nav-item">
-            <a class="nav-link" href="#profile">Profile</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="#projects">Projects</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="#skills">Skills</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="#certificates">Certificates</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="#courses">Courses</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="#achievements">Achievements</a>
-          </li>
+          <li class="nav-item"><a class="nav-link" href="#profile">Profile</a></li>
+          <li class="nav-item"><a class="nav-link" href="#projects">Projects</a></li>
+          <li class="nav-item"><a class="nav-link" href="#skills">Skills</a></li>
+          <li class="nav-item"><a class="nav-link" href="#certificates">Certificates</a></li>
+          <li class="nav-item"><a class="nav-link" href="#courses">Courses</a></li>
+          <li class="nav-item"><a class="nav-link" href="#achievements">Achievements</a></li>
           <li class="nav-item"><a class="nav-link" href="#blog">Blog</a></li>
-          <li class="nav-item">
-            <a class="nav-link" href="#testimonials">Testimonials</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="#work-experiences">Work Experiences</a>
-          </li>
+          <li class="nav-item"><a class="nav-link" href="#testimonials">Testimonials</a></li>
+          <li class="nav-item"><a class="nav-link" href="#work-experiences">Work Experiences</a></li>
           <!-- <li class="nav-item"><a class="nav-link" href="#contact">Contact</a></li> -->
           <!-- <li class="nav-item"><a class="nav-link" href="#progress">Progress</a></li> -->
         </ul>
@@ -110,16 +83,95 @@
       </button>
     </nav>
 
-    <!-- index.html -->
-    <div id="profile"></div>
-    <script>
-      loadSection("profile", "sections/profile.html");
-    </script>
+    <section id="profile" data-aos="fade-up" data-aos-duration="800" data-aos-delay="100">
+      <div class="profile-container">
+        <div class="profile-image">
+          <img
+            src="static/profile.jpg"
+            alt="Profile Picture"
+            loading="lazy"
+            width="250"
+            height="250" />
+        </div>
+        <div class="profile-content">
+          <h2>Profile</h2>
+          <p class="card-text"><strong>Name:</strong> Seanne Cañete</p>
+          <p class="card-text"><strong>Email:</strong> seannecanete32@gmail.com</p>
+          <!-- <p class="card-text"><strong>Phone:</strong> +63 936 943 5635</p> -->
+          <p class="card-text"><strong>Address:</strong> General Santos City, Philippines</p>
+        </div>
+        <div class="educ-bg">
+          <h2>Education</h2>
+          <p class="card-text"><strong>Tertiary:</strong> Mindanao State University - A.Y 2021 - 2025 </p>
+          <p class="card-text"><strong>Senior High School:</strong> Mindanao State University - A.Y 2019 - 2021 </p>
+          <p class="card-text"><strong>Junior High School:</strong> GSC SPED Integrated School - A.Y 2015 - 2019 </p>
+          <p class="card-text"><strong>Elementary:</strong> The Heritage Academy of the Philippines - A.Y 2009 - 2015 </p>
+        </div>
+      </div>
 
-    <div id="projects"></div>
+      <div class="social-links">
+        <a href="https://www.facebook.com/seanne.canete.7/" target="_blank">
+          <i class="fab fa-facebook"></i>
+        </a>
+        <a href="https://x.com/Seanneskie" target="_blank">
+          <i class="fab fa-twitter"></i>
+        </a>
+        <a href="https://www.linkedin.com/in/seanne-ca%C3%B1ete-8b09322a1/" target="_blank">
+          <i class="fab fa-linkedin"></i>
+        </a>
+        <a href="https://github.com/Seanneskie" target="_blank">
+          <i class="fab fa-github"></i>
+        </a>
+        <a href="https://leetcode.com/u/seanneskie32/" target="_blank">
+          <i class="fas fa-code"></i>
+        </a>
+        <a href="static/canete_resume.pdf" target="_blank" download>
+          <i class="fas fa-file-pdf"></i>
+        </a>
+      </div>
+    </section>
+
+    <section id="background" data-aos="fade-right" data-aos-duration="800" data-aos-delay="100">
+      <h2>Background</h2>
+      <p>
+        Hello! I'm Seanne Cañete, an Information Technology undergraduate at
+        Mindanao State University – General Santos City with a passion for
+        full-stack development. I specialize in databases and build intuitive,
+        scalable web applications using Python, Django, JavaScript, React, and
+        data analysis tools.
+      </p>
+      <button class="hire-me" onclick="openGmail()">Hire Me</button>
+    </section>
+
+    <section
+      id="projects"
+      data-aos="fade-left"
+      data-aos-duration="800"
+      data-aos-delay="200">
+      <h2>Projects</h2>
+      <p>
+        Showcasing various web and mobile applications, built using modern
+        technologies like React, Node.js, and Python.
+      </p>
+      <div class="project-filters">
+        <input type="text" id="projectSearch" placeholder="Search projects..." />
+        <div class="tag-buttons">
+          <button class="tag-button active" data-tag="all">All</button>
+          <button class="tag-button" data-tag="AI">AI</button>
+          <button class="tag-button" data-tag="Django">Django</button>
+          <button class="tag-button" data-tag="ReactJS">ReactJS</button>
+          <button class="tag-button" data-tag="Python">Python</button>
+        </div>
+      </div>
+      <div class="project-container" id="projectCards"></div>
+      <div
+        id="projectPagination"
+        class="pagination-buttons"
+        style="text-align: center; margin-top: 20px"></div>
+    </section>
 
     <script>
-      loadSection("projects", "sections/projects.html", () => {
+      document.addEventListener("DOMContentLoaded", () => {
         fetch("assets/datafiles/projects.json")
           .then((res) => res.json())
           .then((projects) => {
@@ -232,15 +284,20 @@
       });
     </script>
 
-    <div id="skills"></div>
+    <section
+      id="skills"
+      data-aos="fade-right"
+      data-aos-duration="800"
+      data-aos-delay="100">
+      <h2>Skills</h2>
+      <p>I have experience with these technologies.</p>
+      <div class="skills-container">
+        <div class="tabs"></div>
+        <!-- Skill content will be injected by skills.js -->
+      </div>
+    </section>
+    <script src="js/skills.js"></script>
 
-    <script>
-      loadSection("skills", "sections/skills.html", () => {
-        const script = document.createElement("script");
-        script.src = "js/skills.js";
-        document.body.appendChild(script);
-      });
-    </script>
     <div id="imageModal" class="modal">
       <span class="close">&times;</span>
       <img class="modal-content" id="modalImg" alt="Certificate image" />
@@ -248,56 +305,158 @@
         id="modalIframe"
         class="modal-content"
         style="display: none"
-        frameborder="0"
-      ></iframe>
+        frameborder="0"></iframe>
     </div>
-    <div id="certificates"></div>
+
+    <!-- Modal Dialog -->
+    <section
+      id="certificates"
+      data-aos="fade-up"
+      data-aos-duration="800"
+      data-aos-delay="100">
+      <h2>Certificates &amp; Seminars</h2>
+      <p class="description">Certificates and seminars that I attended in my career.</p>
+      <div class="certificate-controls">
+        <input
+          type="text"
+          id="certificateSearch"
+          placeholder="Search certificates"
+          class="form-control"
+          style="max-width: 300px; margin-bottom: 10px" />
+        <div
+          id="certificateFilters"
+          class="d-flex flex-wrap justify-content-center"></div>
+      </div>
+      <div class="certificate-grid" id="certificateCards">
+        <!-- Cards will be injected by certificates.js -->
+      </div>
+      <div
+        id="certificatePagination"
+        class="pagination-buttons"
+        style="text-align: center; margin-top: 20px"></div>
+    </section>
     <script src="js/certificates-data.js"></script>
     <script src="js/certificates.js"></script>
     <script>
-      loadSection("certificates", "sections/certificates.html", () => {
+      document.addEventListener("DOMContentLoaded", () => {
         if (typeof initCertificates === "function") initCertificates();
       });
     </script>
 
-    <div id="courses"></div>
-    <script>
-      loadSection("courses", "sections/courses.html", () => {
-        const script = document.createElement("script");
-        script.src = "js/courses.js";
-        document.body.appendChild(script);
-      });
-    </script>
+    <section id="courses" data-aos="fade-up" data-aos-duration="800" data-aos-delay="100">
+      <h2>Courses</h2>
+      <p class="description">Courses taken at Mindanao State University - General Santos.</p>
+      <div class="certificate-grid" id="courseCards"></div>
+    </section>
+    <script src="js/courses.js"></script>
 
-    <div id="blog"></div>
+    <section id="blog" data-aos="fade-up" data-aos-duration="800" data-aos-delay="100">
+      <h2>Blog</h2>
+      <p>Latest posts and articles.</p>
+      <div class="blog-list" id="blogPosts"></div>
+    </section>
     <script src="js/blog.js"></script>
     <script>
-      loadSection("blog", "sections/blog.html", () => {
+      document.addEventListener("DOMContentLoaded", () => {
         if (typeof loadBlogPosts === "function") loadBlogPosts();
       });
     </script>
-    <div id="achievements"></div>
-    <script>
-      loadSection("achievements", "sections/achievements.html");
-    </script>
-    <div id="testimonials"></div>
-    <!-- <div id="contactSection"></div> -->
 
+    <section id="achievements" data-aos="fade-left" data-aos-duration="800" data-aos-delay="200">
+      <h2>Achievements</h2>
+      <ul class="timeline">
+        <li>
+          <i class="fas fa-trophy"></i>
+          <div class="achievement-content">
+            <strong>JITS IT Week 2023 - Hackathon | January 2023</strong>
+            <p>Champion</p>
+          </div>
+        </li>
+        <li>
+          <i class="fas fa-trophy"></i>
+          <div class="achievement-content">
+            <strong>JITS IT Week 2024 - Hackathon | April 2024</strong>
+            <p>Champion</p>
+          </div>
+        </li>
+        <li>
+          <i class="fas fa-award"></i>
+          <div class="achievement-content">
+            <strong>Hack4Gov3 – Region 12 Qualifier | August 2024</strong>
+            <p>Champion &amp; Excellence Awardee</p>
+          </div>
+        </li>
+        <li>
+          <i class="fas fa-medal"></i>
+          <div class="achievement-content">
+            <strong>Trend Micro – Trend University CTF Qualifier | August 2024</strong>
+            <p>1st Place</p>
+          </div>
+        </li>
+        <li>
+          <i class="fas fa-medal"></i>
+          <div class="achievement-content">
+            <strong>Trend Micro – Trend University CTF Finals | September 2024</strong>
+            <p>4th Place</p>
+          </div>
+        </li>
+        <li>
+          <i class="fas fa-flag-checkered"></i>
+          <div class="achievement-content">
+            <strong>Hack4Gov3 – National Finals | October 2024</strong>
+            <p>4th Place</p>
+          </div>
+        </li>
+        <li>
+          <i class="fas fa-graduation-cap"></i>
+          <div class="achievement-content">
+            <strong>Cum Laude | June 2025</strong>
+            <p>Mindanao State University - General Santos</p>
+          </div>
+        </li>
+        <li>
+          <i class="fas fa-award"></i>
+          <div class="achievement-content">
+            <strong>PSITE12 Most Outstanding IT Student | June 2025</strong>
+            <p>Awarded by PSITEXII and Dr. Lumer Jude P. Doce</p>
+          </div>
+        </li>
+      </ul>
+    </section>
+
+    <section id="testimonials" data-aos="fade-up" data-aos-duration="800" data-aos-delay="100">
+      <h2>Testimonials</h2>
+      <div id="testimonialCarousel" class="carousel slide" data-ride="carousel">
+        <div class="carousel-inner" id="testimonialCarouselInner"></div>
+        <a class="carousel-control-prev" href="#testimonialCarousel" role="button" data-slide="prev">
+          <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+          <span class="sr-only">Previous</span>
+        </a>
+        <a class="carousel-control-next" href="#testimonialCarousel" role="button" data-slide="next">
+          <span class="carousel-control-next-icon" aria-hidden="true"></span>
+          <span class="sr-only">Next</span>
+        </a>
+      </div>
+    </section>
     <script src="js/testimonials.js"></script>
     <script>
-      // Load Testimonials Section
-      loadSection("testimonials", "sections/testimonials.html", () => {
+      document.addEventListener("DOMContentLoaded", () => {
         if (typeof initTestimonials === "function") initTestimonials();
       });
-
-      // Load Contact Section (disabled)
-      // loadSection('contactSection', 'sections/contact.html');
     </script>
 
-    <div id="work-experiences"></div>
+    <section
+      id="work-experiences"
+      class="container-fluid"
+      data-aos="fade-right"
+      data-aos-duration="800"
+      data-aos-delay="200">
+      <h2 class="mb-4" style="color: var(--text)">Work Experiences</h2>
+      <div id="workExperienceContainer"></div>
+    </section>
     <script src="js/work-experiences.js"></script>
     <script>
-      loadSection("work-experiences", "sections/work-experiences.html", () => {
+      document.addEventListener("DOMContentLoaded", () => {
         if (typeof initWorkExperiences === "function") initWorkExperiences();
       });
     </script>
@@ -307,8 +466,7 @@
       id="progress"
       data-aos="fade-up"
       data-aos-duration="800"
-      data-aos-delay="200"
-    >
+      data-aos-delay="200">
       <h2>Progress</h2>
       <div class="tabs">
         <button class="tablinks" onclick="openProgressTab(event, 'capture')">
@@ -420,9 +578,8 @@
       </div>
     </section>
     -->
-    <div id="footer"></div>
 
-    <!-- FontAwesome for icons -->
+    <div id="footer"></div>
 
     <!-- Bootstrap JS and dependencies -->
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
@@ -431,67 +588,39 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.js"></script>
     <script>
       AOS.init({
-        offset: 120, // Offset from the original trigger point
-        delay: 0, // Delay before the animation starts
-        duration: 800, // Duration of animation
-        easing: "ease", // Easing function
-        once: true, // Whether animation should happen only once - while scrolling down
-        mirror: false, // Whether elements should animate out while scrolling past them
+        offset: 120,
+        delay: 0,
+        duration: 800,
+        easing: "ease",
+        once: true,
+        mirror: false,
       });
-      loadSection('footer', 'sections/footer.html');
     </script>
     <script>
       $("body").scrollspy({ target: "#mainNav", offset: 70 });
     </script>
-    <script>
-      function openCategory(evt, categoryName) {
-        var i, tabcontent, tablinks;
-
-        // Hide all tab content by default
-        tabcontent = document.getElementsByClassName("tabcontent");
-        for (i = 0; i < tabcontent.length; i++) {
-          tabcontent[i].style.display = "none";
-        }
-
-        // Remove the active class from all tabs
-        tablinks = document.getElementsByClassName("tablinks");
-        for (i = 0; i < tablinks.length; i++) {
-          tablinks[i].className = tablinks[i].className.replace(" active", "");
-        }
-
-        // Show the current tab and add the active class to the button that opened it
-        document.getElementById(categoryName).style.display = "block";
-        evt.currentTarget.className += " active";
-      }
-
-      // Open the first tab by default
-      document.addEventListener("DOMContentLoaded", function () {
-        document.querySelector(".tabs button").click();
-      });
-    </script>
-
     <!-- <script src="js/progress-tabs.js"></script> -->
     <script src="js/image-modal.js"></script>
     <script src="js/theme-toggle.js"></script>
     <!-- <script src="js/progress-update.js"></script> -->
-
+    <script src="js/main.js"></script>
     <script>
       function openGmail() {
         const email = "seannecanete32@gmail.com";
         const subject = "Job Offer for Seanne Cañete";
         const body = `Dear Seanne,
-    
+
     We are pleased to inform you that after careful consideration, we would like to extend an offer for you to join our team as [Job Title] at [Company Name].
-    
+
     We believe your skills and experience are a perfect fit for our organization, and we are excited to have you contribute to our projects. Please find the details of the offer below:
-    
+
     - Position: [Job Title]
     - Start Date: [Start Date]
     - Salary: [Salary Details]
     - Other Benefits: [Benefits]
-    
+
     If you accept this offer, please reply to this email with your confirmation. We look forward to welcoming you to our team.
-    
+
     Best regards,
     [Hiring Manager's Name]
     [Company Name]`;
@@ -511,3 +640,4 @@
     </script>
   </body>
 </html>
+

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,9 @@
+document.addEventListener('DOMContentLoaded', () => {
+  fetch('sections/footer.html')
+    .then(res => res.text())
+    .then(html => {
+      const footer = document.getElementById('footer');
+      if (footer) footer.innerHTML = html;
+    })
+    .catch(err => console.error('Error loading footer:', err));
+});


### PR DESCRIPTION
## Summary
- Embed profile, projects, and other sections directly in `index.html` instead of loading them via `section-loader.js`.
- Add `main.js` to fetch the footer partial and remove dynamic loader calls.

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896a656aed883298efff826d989cc88