### PR TITLE
chore: add CSS linting

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -28,6 +28,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install dependencies
+        run: npm install
+      - name: Lint CSS
+        run: npm run lint:css
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Build with Jekyll

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -31,6 +31,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install dependencies
+        run: npm install
+      - name: Lint CSS
+        run: npm run lint:css
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["stylelint-config-standard", "stylelint-config-tailwindcss"]
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Seanne Portfolio
+
+## CSS Linting
+
+Install dependencies with:
+
+```bash
+npm install
+```
+
+Run the CSS linter before committing changes:
+
+```bash
+npm run lint:css
+```
+
+This checks all CSS files against standard and Tailwind conventions.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "seanne-portfolio",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "lint:css": "stylelint \"**/*.css\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "stylelint": "*",
+    "stylelint-config-tailwindcss": "*",
+    "stylelint-config-standard": "*"
+  }
+}


### PR DESCRIPTION
## Summary
- set up stylelint with Tailwind and standard configs
- document CSS linting instructions
- run CSS linting in GitHub workflows

## Testing
- `npm install --save-dev stylelint stylelint-config-tailwindcss stylelint-config-standard` *(fails: 403 Forbidden)*
- `npm run lint:css` *(fails: stylelint: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896bfafe6e48329b0e4efd6bf5d47b3