### PR TITLE
fix: safeguard tabs initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
     <meta property="og:image" content="static/profile.jpg" />
     <meta name="author" content="Seanneskie" />
     <link rel="icon" type="image/png" href="static/favicon-32x32.png" />
-    <!-- Tailwind CSS -->
+    <!-- Tailwind CSS (CDN for development; use CLI or PostCSS in production) -->
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="js/tailwind-config.js"></script>
 
@@ -459,9 +459,12 @@
         evt.currentTarget.className += " active";
       }
 
-      // Open the first tab by default
+      // Open the first tab by default if tabs exist
       document.addEventListener("DOMContentLoaded", function () {
-        document.querySelector(".tabs button").click();
+        const firstTab = document.querySelector(".tabs button");
+        if (firstTab) {
+          firstTab.click();
+        }
       });
     </script>
 


### PR DESCRIPTION
## Summary
- avoid runtime errors when tab controls are absent
- document that Tailwind CDN is for development and ignore build artifacts

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:css` (fails: No files matching the pattern "**/*.css" were found.)
- `npm run check:css` (fails: CSS policy violations found)


------
https://chatgpt.com/codex/tasks/task_e_6896ce52b6708329b6ab6b8ea69e897b