### PR TITLE
Add charcoal background style and dark text handling

### DIFF
--- a/js/gallery.js
+++ b/js/gallery.js
@@ -84,8 +84,8 @@ function renderImages(project, images) {
     item.className = `carousel-item${index === 0 ? ' active' : ''}`;
     item.innerHTML = `
       <img src="../static/${project}/images/${file}" class="d-block w-100" alt="${caption}">
-      <div class="carousel-caption d-none d-md-block">
-        <p>${caption}</p>
+      <div class="carousel-caption d-none d-md-block text-dark">
+        <p class="text-dark">${caption}</p>
       </div>`;
     inner.appendChild(item);
   });
@@ -120,6 +120,7 @@ function renderPDFs(project, pdfs) {
 
   const heading = document.createElement('h5');
   heading.textContent = 'Downloads';
+  heading.className = 'text-dark';
   container.appendChild(heading);
 
   const list = document.createElement('div');
@@ -129,7 +130,7 @@ function renderPDFs(project, pdfs) {
     const link = document.createElement('a');
     link.href = `../static/${project}/pdfs/${file}`;
     link.download = '';
-    link.className = 'list-group-item list-group-item-action';
+    link.className = 'list-group-item list-group-item-action text-dark';
     link.textContent = caption;
     list.appendChild(link);
   });

--- a/static/index.css
+++ b/static/index.css
@@ -123,6 +123,15 @@ p {
     color: var(--text);
 }
 
+.bg-charcoal {
+    background-color: var(--charcoal);
+    color: var(--text-hover);
+}
+
+table, th, td {
+    color: var(--text-dark);
+}
+
 
 
 


### PR DESCRIPTION
## Summary
- add `bg-charcoal` CSS class for project details and enforce dark text for tables
- update gallery rendering to use dark font colors for captions and download links

## Testing
- `node --check js/gallery.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896e266430083299762c53e035275fb