### PR TITLE
Add search and tag filtering for projects

### DIFF
--- a/sections/projects.html
+++ b/sections/projects.html
@@ -37,5 +37,12 @@
   data-aos-delay="200"
 >
   <h2 class="mb-4" style="color: var(--text)">Projects</h2>
+  <input
+    type="text"
+    id="projectSearch"
+    class="form-control mb-3"
+    placeholder="Search projects..."
+  />
+  <div id="tagButtonContainer" class="mb-3"></div>
   <div class="accordion" id="projectAccordion"></div>
 </section>


### PR DESCRIPTION
## Summary
- add project search field and tag button container above accordion
- generate tag buttons from project data and filter cards by search text and tag selection

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896ede2cb0083299ec4e4af4142250b