### PR TITLE
Add search and tag filtering for certificates

### DIFF
--- a/sections/certificates.html
+++ b/sections/certificates.html
@@ -6,6 +6,13 @@
   data-aos-delay="100"
 >
   <h2 class="mb-4" style="color: var(--text)">Certificates &amp; Seminars</h2>
+  <input
+    type="text"
+    id="certificateSearch"
+    class="form-control mb-3"
+    placeholder="Search certificates"
+  />
+  <div class="tag-buttons mb-3" id="certificateTags"></div>
   <div class="accordion" id="certificateAccordion"></div>
 </section>
 


### PR DESCRIPTION
## Summary
- add search bar and tag button area in certificates section
- load unique tags from certificate data and render filter buttons
- enable live filtering of certificate cards by text and tag while preserving two-column layout

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896ede40be88329960558677f9b5c19