### PR TITLE
Enhance blog section with search, sort, and skeleton loaders

### DIFF
--- a/js/blog.js
+++ b/js/blog.js
@@ -1,21 +1,153 @@
 async function loadBlogPosts() {
+  const container = document.getElementById('blogPosts');
+  if (!container) return;
+
+  // Skeletons while loading
+  renderSkeletons(container, 6);
+
   try {
-    const response = await fetch('assets/datafiles/blog-posts.json');
+    const response = await fetch('assets/datafiles/blog-posts.json', { cache: 'no-store' });
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
     const posts = await response.json();
-    const container = document.getElementById('blogPosts');
-    if (!container) return;
-    posts.forEach((post) => {
-      const article = document.createElement('article');
-      article.className = 'blog-post';
-      article.innerHTML = `
-        <h3>${post.title}</h3>
-        <p class="blog-date">${post.date}</p>
-        <p>${post.description}</p>
-        <a href="${post.url}" target="_blank" class="btn btn-secondary">Read More</a>
-      `;
-      container.appendChild(article);
-    });
+
+    // Optional: basic search/sort wiring
+    const searchEl = document.getElementById('blogSearch');
+    const sortEl   = document.getElementById('blogSort');
+
+    const state = { query: '', sort: 'newest' };
+    if (searchEl) searchEl.addEventListener('input', e => { state.query = e.target.value.trim().toLowerCase(); render(); });
+    if (sortEl)   sortEl.addEventListener('change', e => { state.sort = e.target.value; render(); });
+
+    function render() {
+      container.innerHTML = '';
+      let items = [...posts];
+
+      // filter
+      if (state.query) {
+        items = items.filter(p => (
+          (p.title || '').toLowerCase().includes(state.query) ||
+          (p.description || '').toLowerCase().includes(state.query) ||
+          (Array.isArray(p.tags) ? p.tags.join(' ') : '').toLowerCase().includes(state.query)
+        ));
+      }
+
+      // sort
+      items.sort((a, b) => {
+        const da = new Date(a.date), db = new Date(b.date);
+        return state.sort === 'oldest' ? da - db : db - da;
+      });
+
+      if (!items.length) {
+        container.innerHTML = `
+          <div class="col-12">
+            <div class="alert alert-info mb-0">No posts found. Try a different search.</div>
+          </div>`;
+        return;
+      }
+
+      // draw
+      items.forEach(post => container.appendChild(renderCard(post)));
+    }
+
+    render();
   } catch (error) {
+    container.innerHTML = `
+      <div class="col-12">
+        <div class="alert alert-danger mb-0">
+          <strong>Couldn’t load blog posts.</strong> Please try again later.
+          <div class="small text-muted mt-1">${String(error)}</div>
+        </div>
+      </div>`;
     console.error('Error loading blog posts:', error);
   }
 }
+
+function renderSkeletons(container, count = 6) {
+  container.innerHTML = '';
+  for (let i = 0; i < count; i++) {
+    const col = document.createElement('div');
+    col.className = 'col-12 col-md-6 col-lg-4';
+    col.innerHTML = `
+      <div class="skeleton p-3">
+        <div style="height: 160px; border-radius: .5rem; background:#dee2e6;"></div>
+        <div class="mt-3" style="height: 18px; width: 70%; background:#dee2e6; border-radius:.25rem;"></div>
+        <div class="mt-2" style="height: 12px; width: 50%; background:#e5e7eb; border-radius:.25rem;"></div>
+        <div class="mt-3" style="height: 44px; background:#f1f3f5; border-radius:.25rem;"></div>
+      </div>`;
+    container.appendChild(col);
+  }
+}
+
+function renderCard(post) {
+  const {
+    title = 'Untitled',
+    date = '',
+    description = '',
+    url = '#',
+    image,            // optional: absolute/relative URL
+    tags = []         // optional: ["Django","AI"]
+  } = post;
+
+  const col = document.createElement('div');
+  col.className = 'col-12 col-md-6 col-lg-4 d-flex';
+
+  const prettyDate = safePrettyDate(date);
+  const readTime = estimateReadTime(description, post.wordCount);
+
+  col.innerHTML = `
+    <article class="card blog-card border-0 shadow-sm flex-grow-1">
+      ${image ? `
+        <img src="${escapeAttr(image)}" class="card-img-top blog-cover" alt="${escapeAttr(title)} cover" loading="lazy" />`
+      : `
+        <div class="blog-cover w-100 d-flex align-items-center justify-content-center bg-light">
+          <span class="text-muted small">No cover image</span>
+        </div>`}
+      <div class="card-body d-flex flex-column">
+        <h3 class="h5 card-title mb-2">${escapeHTML(title)}</h3>
+        <div class="d-flex align-items-center gap-2 mb-2 text-muted small">
+          <time datetime="${escapeAttr(date)}">${prettyDate}</time>
+          <span aria-hidden="true">•</span>
+          <span>${readTime} min read</span>
+        </div>
+        <p class="card-text blog-desc mb-3">${escapeHTML(description)}</p>
+        ${Array.isArray(tags) && tags.length ? `
+          <div class="mb-3">
+            ${tags.slice(0,4).map(t => `<span class="badge bg-secondary blog-badge me-1 mb-1">${escapeHTML(t)}</span>`).join('')}
+            ${tags.length > 4 ? `<span class="badge bg-light text-muted blog-badge">+${tags.length-4}</span>` : ''}
+          </div>` : ''
+        }
+        <div class="mt-auto d-flex align-items-center gap-2">
+          <a href="${escapeAttr(url)}" target="_blank" rel="noopener" class="btn btn-sm btn-primary">Read More</a>
+          <a href="${escapeAttr(url)}" target="_blank" rel="noopener" class="btn btn-sm btn-outline-secondary" aria-label="Share this post"
+             onclick="navigator.share ? navigator.share({ title: '${escapeAttr(title)}', url: '${escapeAttr(url)}' }) : window.open('${escapeAttr(url)}','_blank'); return false;">
+            Share
+          </a>
+        </div>
+      </div>
+    </article>
+  `;
+  return col;
+}
+
+// utils
+function safePrettyDate(iso) {
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return '—';
+  return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+}
+function estimateReadTime(desc = '', wordCount) {
+  const words = typeof wordCount === 'number' ? wordCount : (desc || '').split(/\s+/).filter(Boolean).length;
+  return Math.max(1, Math.round(words / 220));
+}
+function escapeHTML(str = '') {
+  const replacements = { '&': '&amp;', '<': '&lt;', '>': '&gt;', "'": '&#39;' };
+  replacements['"'] = '&quot;';
+  return String(str).replace(/[&<>"']/g, s => replacements[s]);
+}
+function escapeAttr(str = '') {
+  return escapeHTML(str).replace(/`/g, '&#96;');
+}
+
+// kick off
+loadBlogPosts();
+

--- a/sections/blog.html
+++ b/sections/blog.html
@@ -1,5 +1,16 @@
 <section id="blog" data-aos="fade-up" data-aos-duration="800" data-aos-delay="100">
   <h2>Blog</h2>
   <p>Latest posts and articles.</p>
-  <div class="blog-list" id="blogPosts"></div>
+
+  <!-- Controls -->
+  <div class="d-flex flex-wrap align-items-center gap-2 mb-3">
+    <input id="blogSearch" class="form-control" placeholder="Search posts…" style="max-width: 280px;" />
+    <select id="blogSort" class="form-select" style="max-width: 180px;">
+      <option value="newest">Newest</option>
+      <option value="oldest">Oldest</option>
+    </select>
+  </div>
+
+  <!-- Posts grid -->
+  <div id="blogPosts" class="row g-3"></div>
 </section>

--- a/static/index.css
+++ b/static/index.css
@@ -182,23 +182,54 @@ table, th, td {
     background-color: var(--coal);
 }
 
-.blog-post {
-    background-color: var(--charcoal);
-    color: var(--text);
-    padding: 20px;
-    border-radius: 8px;
-    margin-bottom: 20px;
+.blog-card {
+    transition: transform .15s ease, box-shadow .15s ease;
+    height: 100%;
 }
 
-.blog-post h3 {
-    color: var(--text-hover);
-    margin-top: 0;
+.blog-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, .12);
 }
 
-.blog-date {
-    font-size: 0.9rem;
-    color: var(--text);
-    margin-bottom: 10px;
+.blog-desc {
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    min-height: 3.8em;
+}
+
+.blog-badge {
+    font-size: .75rem;
+}
+
+.blog-cover {
+    object-fit: cover;
+    height: 160px;
+}
+
+.skeleton {
+    position: relative;
+    overflow: hidden;
+    background: #e9ecef;
+    border-radius: .5rem;
+    min-height: 220px;
+}
+
+.skeleton::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(90deg, transparent, rgba(255, 255, 255, .45), transparent);
+    animation: shimmer 1.2s infinite;
+    transform: translateX(-100%);
+}
+
+@keyframes shimmer {
+    100% {
+        transform: translateX(100%);
+    }
 }
 
 


### PR DESCRIPTION
## Summary
- Replace blog section with searchable/sortable interface and improved card layout
- Add skeleton loaders, tags, and read-time estimates to blog posts
- Style blog cards, badges, and shimmer effect

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897f41daf70832999bcde03394d5627