### PR TITLE
style: refine blog card layout and colors

### DIFF
--- a/js/blog.js
+++ b/js/blog.js
@@ -101,7 +101,7 @@ function renderCard(post) {
   const readTime = estimateReadTime(description, post.wordCount);
 
   col.innerHTML = `
-    <article class="card blog-card border-0 shadow-sm flex-grow-1">
+    <article class="card blog-card flex-grow-1">
       ${image ? `
         <img src="${escapeAttr(image)}" class="card-img-top blog-cover" alt="${escapeAttr(title)} cover" loading="lazy" />`
       : `
@@ -123,7 +123,7 @@ function renderCard(post) {
           </div>` : ''
         }
         <div class="mt-auto d-flex align-items-center gap-2">
-          <a href="${escapeAttr(url)}" target="_blank" rel="noopener" class="btn btn-sm btn-primary">Read More</a>
+          <a href="${escapeAttr(url)}" target="_blank" rel="noopener" class="btn btn-sm btn-charcoal">Read More</a>
           <a href="${escapeAttr(url)}" target="_blank" rel="noopener" class="btn btn-sm btn-outline-secondary" aria-label="Share this post"
              onclick="navigator.share ? navigator.share({ title: '${escapeAttr(title)}', url: '${escapeAttr(url)}' }) : window.open('${escapeAttr(url)}','_blank'); return false;">
             Share

--- a/sections/blog.html
+++ b/sections/blog.html
@@ -12,5 +12,5 @@
   </div>
 
   <!-- Posts grid -->
-  <div id="blogPosts" class="row g-3"></div>
+  <div id="blogPosts" class="row gx-3 gy-4"></div>
 </section>

--- a/static/index.css
+++ b/static/index.css
@@ -185,11 +185,13 @@ table, th, td {
 .blog-card {
     transition: transform .15s ease, box-shadow .15s ease;
     height: 100%;
+    border: 1px solid var(--charcoal);
+    box-shadow: 0 0.25rem 0.5rem rgba(0, 0, 0, .1);
 }
 
 .blog-card:hover {
     transform: translateY(-2px);
-    box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, .12);
+    box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, .15);
 }
 
 .blog-desc {
@@ -198,6 +200,9 @@ table, th, td {
     -webkit-box-orient: vertical;
     overflow: hidden;
     min-height: 3.8em;
+    background-color: var(--charcoal);
+    padding: .75rem;
+    border-radius: .25rem;
 }
 
 .blog-badge {
@@ -207,6 +212,18 @@ table, th, td {
 .blog-cover {
     object-fit: cover;
     height: 160px;
+}
+
+.btn-charcoal {
+    background-color: var(--charcoal);
+    border-color: var(--charcoal);
+    color: var(--text-hover);
+}
+
+.btn-charcoal:hover {
+    background-color: var(--obsidian);
+    border-color: var(--obsidian);
+    color: var(--text-hover);
 }
 
 .skeleton {


### PR DESCRIPTION
## Summary
- increase vertical spacing in blog grid
- restyle blog cards with charcoal borders, shadows, and description backgrounds
- add charcoal button style for blog links

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897fab2188c83299062dc83ace2d525