### PR TITLE
Add blog sort options and refine filter layout

### DIFF
--- a/js/blog.js
+++ b/js/blog.js
@@ -33,8 +33,16 @@ async function loadBlogPosts() {
 
       // sort
       items.sort((a, b) => {
-        const da = new Date(a.date), db = new Date(b.date);
-        return state.sort === 'oldest' ? da - db : db - da;
+        switch (state.sort) {
+          case 'oldest':
+            return new Date(a.date) - new Date(b.date);
+          case 'title-az':
+            return (a.title || '').localeCompare(b.title || '');
+          case 'title-za':
+            return (b.title || '').localeCompare(a.title || '');
+          default:
+            return new Date(b.date) - new Date(a.date);
+        }
       });
 
       if (!items.length) {

--- a/sections/blog.html
+++ b/sections/blog.html
@@ -3,11 +3,13 @@
   <p>Latest posts and articles.</p>
 
   <!-- Controls -->
-  <div class="d-flex flex-wrap align-items-center gap-2 mb-3">
+  <div class="d-flex flex-wrap align-items-center gap-2">
     <input id="blogSearch" class="form-control" placeholder="Search posts…" style="max-width: 280px;" />
     <select id="blogSort" class="form-select" style="max-width: 180px;">
       <option value="newest">Newest</option>
       <option value="oldest">Oldest</option>
+      <option value="title-az">Title A–Z</option>
+      <option value="title-za">Title Z–A</option>
     </select>
   </div>
 


### PR DESCRIPTION
## Summary
- extend blog sorting dropdown with title-based options
- adjust filter controls layout by removing bottom margin

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689803ad287083298e593ddce812d4f8