### PR TITLE
Use Bootstrap input group for project search

### DIFF
--- a/sections/projects.html
+++ b/sections/projects.html
@@ -37,12 +37,20 @@
   data-aos-delay="200"
 >
   <h2 class="mb-4" style="color: var(--text)">Projects</h2>
-  <input
-    type="text"
-    id="projectSearch"
-    class="form-control mb-3"
-    placeholder="Search projects..."
-  />
+  <div class="input-group mb-2 mb-md-0 mr-md-2" style="max-width: 360px;">
+    <div class="input-group-prepend">
+      <span class="input-group-text">
+        <i class="fa fa-search" aria-hidden="true"></i>
+      </span>
+    </div>
+    <input
+      type="text"
+      id="projectSearch"
+      class="form-control"
+      placeholder="Search projects..."
+      aria-label="Search projects"
+    />
+  </div>
   <div id="tagButtonContainer" class="mb-3"></div>
   <div class="accordion" id="projectAccordion"></div>
 </section>


### PR DESCRIPTION
## Summary
- Replace standalone project search input with Bootstrap input group and search icon to mirror blog styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898070501f88329a795a7e2b7935649