### PR TITLE
Use input-group for certificate search

### DIFF
--- a/sections/certificates.html
+++ b/sections/certificates.html
@@ -6,12 +6,20 @@
   data-aos-delay="100"
 >
   <h2 class="mb-4" style="color: var(--text)">Certificates &amp; Seminars</h2>
-  <input
-    type="text"
-    id="certificateSearch"
-    class="form-control mb-3"
-    placeholder="Search certificates"
-  />
+  <div class="input-group mb-3" style="max-width: 360px;">
+    <div class="input-group-prepend">
+      <span class="input-group-text">
+        <i class="fa fa-search" aria-hidden="true"></i>
+      </span>
+    </div>
+    <input
+      type="text"
+      id="certificateSearch"
+      class="form-control"
+      placeholder="Search certificates"
+      aria-label="Search certificates"
+    />
+  </div>
   <div class="tag-buttons mb-3" id="certificateTags"></div>
   <div class="accordion" id="certificateAccordion"></div>
 </section>


### PR DESCRIPTION
## Summary
- Wrap certificates search bar in a Bootstrap input group with a search icon and width constraint

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/Seanne-Portfolio/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68980706ade0832985488a98d1ea178f