### PR TITLE
refactor: extract reusable search box

### DIFF
--- a/docs/search-box.md
+++ b/docs/search-box.md
@@ -1,0 +1,21 @@
+# Shared Search Box Component
+
+A reusable Bootstrap search box lives at `sections/components/search-box.html`.
+Use the helper function `loadSearchBox` to inject it into a section and
+customize the input id and placeholder text.
+
+## Usage
+
+1. **Add a container** where the search box should appear in your section HTML:
+   ```html
+   <div id="mySearchBox"></div>
+   ```
+
+2. **Load the partial** after the section is rendered:
+   ```javascript
+   loadSearchBox('mySearchBox', 'myInputId', 'Search items...', 'Search items', () => {
+     // optional: code that relies on the input existing
+   });
+   ```
+
+This ensures a consistent search UI across sections without duplicating markup.

--- a/index.html
+++ b/index.html
@@ -45,6 +45,7 @@
     <!-- Custom CSS -->
     <link href="static/index.css" rel="stylesheet" />
     <script src="js/section-loader.js"></script>
+    <script src="js/search-box.js"></script>
     </head>
   <body style="width: 100vw; overflow-x: hidden">
     <div class="cover">
@@ -120,7 +121,9 @@
     <script src="js/projects.js"></script>
     <script>
       loadSection("projects", "sections/projects.html", () => {
-        if (typeof initProjects === "function") initProjects();
+        loadSearchBox("projectSearchBox", "projectSearch", "Search projects...", "Search projects", () => {
+          if (typeof initProjects === "function") initProjects();
+        });
       });
     </script>
 
@@ -147,7 +150,9 @@
     <script src="js/certificates.js"></script>
     <script>
       loadSection("certificates", "sections/certificates.html", () => {
-        if (typeof initCertificates === "function") initCertificates();
+        loadSearchBox("certificateSearchBox", "certificateSearch", "Search certificates", "Search certificates", () => {
+          if (typeof initCertificates === "function") initCertificates();
+        });
       });
     </script>
 
@@ -164,7 +169,9 @@
     <script src="js/blog.js"></script>
     <script>
       loadSection("blog", "sections/blog.html", () => {
-        if (typeof loadBlogPosts === "function") loadBlogPosts();
+        loadSearchBox("blogSearchBox", "blogSearch", "Search posts…", "Search blog posts", () => {
+          if (typeof loadBlogPosts === "function") loadBlogPosts();
+        });
       });
     </script>
     <div id="achievements"></div>

--- a/js/search-box.js
+++ b/js/search-box.js
@@ -1,0 +1,16 @@
+function loadSearchBox(containerId, inputId, placeholder, ariaLabel, callback) {
+  loadSection(containerId, 'sections/components/search-box.html', () => {
+    const container = document.getElementById(containerId);
+    if (container) {
+      const input = container.querySelector('input');
+      if (input) {
+        if (inputId) input.id = inputId;
+        if (placeholder) input.placeholder = placeholder;
+        if (ariaLabel) input.setAttribute('aria-label', ariaLabel);
+      }
+    }
+    if (typeof callback === 'function') {
+      callback();
+    }
+  });
+}

--- a/sections/blog.html
+++ b/sections/blog.html
@@ -6,18 +6,7 @@
 <div class="d-flex flex-column flex-md-row align-items-stretch align-items-md-center w-100">
 
   <!-- Search -->
-  <div class="input-group mb-2 mb-md-0 mr-md-2" style="max-width: 360px;">
-    <div class="input-group-prepend">
-      <span class="input-group-text">
-        <!-- Optional: Font Awesome -->
-        <i class="fa fa-search" aria-hidden="true"></i>
-      </span>
-    </div>
-    <input id="blogSearch"
-           class="form-control"
-           placeholder="Search posts…"
-           aria-label="Search blog posts">
-  </div>
+  <div id="blogSearchBox"></div>
 
   <!-- Sort -->
   <div class="d-flex">

--- a/sections/certificates.html
+++ b/sections/certificates.html
@@ -6,20 +6,7 @@
   data-aos-delay="100"
 >
   <h2 class="mb-4" style="color: var(--text)">Certificates &amp; Seminars</h2>
-  <div class="input-group mb-3" style="max-width: 360px;">
-    <div class="input-group-prepend">
-      <span class="input-group-text">
-        <i class="fa fa-search" aria-hidden="true"></i>
-      </span>
-    </div>
-    <input
-      type="text"
-      id="certificateSearch"
-      class="form-control"
-      placeholder="Search certificates"
-      aria-label="Search certificates"
-    />
-  </div>
+  <div id="certificateSearchBox"></div>
   <div class="tag-buttons mb-3" id="certificateTags"></div>
   <div class="accordion" id="certificateAccordion"></div>
 </section>

--- a/sections/components/search-box.html
+++ b/sections/components/search-box.html
@@ -1,0 +1,8 @@
+<div class="input-group mb-2 mb-md-0 mr-md-2" style="max-width: 360px;">
+  <div class="input-group-prepend">
+    <span class="input-group-text">
+      <i class="fa fa-search" aria-hidden="true"></i>
+    </span>
+  </div>
+  <input type="text" class="form-control" />
+</div>

--- a/sections/projects.html
+++ b/sections/projects.html
@@ -37,20 +37,7 @@
   data-aos-delay="200"
 >
   <h2 class="mb-4" style="color: var(--text)">Projects</h2>
-  <div class="input-group mb-2 mb-md-0 mr-md-2" style="max-width: 360px;">
-    <div class="input-group-prepend">
-      <span class="input-group-text">
-        <i class="fa fa-search" aria-hidden="true"></i>
-      </span>
-    </div>
-    <input
-      type="text"
-      id="projectSearch"
-      class="form-control"
-      placeholder="Search projects..."
-      aria-label="Search projects"
-    />
-  </div>
+  <div id="projectSearchBox"></div>
   <div id="tagButtonContainer" class="mb-3"></div>
   <div class="accordion" id="projectAccordion"></div>
 </section>


### PR DESCRIPTION
## Summary
- centralize Bootstrap search input as `sections/components/search-box.html`
- load the search box in blog, projects and certificates via new `loadSearchBox` helper
- document component usage for future sections

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68983801af608329bccce9cee5335a6c