### PR TITLE
Add headless e-commerce mini-store project

### DIFF
--- a/app/project-details/headless-ecommerce-mini-store/page.tsx
+++ b/app/project-details/headless-ecommerce-mini-store/page.tsx
@@ -1,0 +1,9 @@
+import ProjectHtml from "@/components/project-details/ProjectHtml";
+
+export default async function Page() {
+  return (
+    <main className="container mx-auto max-w-5xl px-4 py-12">
+      <ProjectHtml slug="headless-ecommerce-mini-store" />
+    </main>
+  );
+}

--- a/public/data/projects.json
+++ b/public/data/projects.json
@@ -234,5 +234,22 @@
     "githubLabel": "View on GitHub",
     "details": "project-details/ai-powered-email-generator",
     "period": "Aug 2025 - Present"
+  },
+  {
+    "title": "Headless E-Commerce Mini-Store",
+    "image": "/static/placeholders/next.png",
+    "alt": "Headless E-Commerce Mini-Store Image",
+    "description": "Modern headless e-commerce platform using Next.js, Shopify Storefront GraphQL API, and AWS.",
+    "tags": [
+      "NextJS",
+      "Shopify",
+      "GraphQL",
+      "AWS",
+      "E-Commerce"
+    ],
+    "github": null,
+    "githubLabel": "View Site",
+    "details": "project-details/headless-ecommerce-mini-store",
+    "period": "Aug 2025 - Aug 2025"
   }
 ]

--- a/public/project-details/headless-ecommerce-mini-store.html
+++ b/public/project-details/headless-ecommerce-mini-store.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Headless E-Commerce Mini-Store</title>
+  <style>
+    body { font-family: sans-serif; line-height: 1.6; }
+    img { max-width: 100%; height: auto; }
+  </style>
+</head>
+<body>
+  <h1>Headless E-Commerce Mini-Store</h1>
+  <p>Modern headless e-commerce platform built using Next.js for the frontend, Shopify Storefront GraphQL API for product and checkout data, and AWS for hosting and backend services.</p>
+  <!-- Example image: -->
+  <!-- <img src="/static/example.jpg" alt="Example image description" /> -->
+  <!-- Example PDF embed: -->
+  <!-- <embed src="/static/example.pdf" type="application/pdf" width="100%" height="600px" /> -->
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Headless E-Commerce Mini-Store entry with Next.js, Shopify GraphQL, and AWS details
- include project detail page and routing for the new mini-store

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3d96e83a08329a81954aab3588c64