### PR TITLE
Add Order & Inventory Management API details

### DIFF
--- a/app/project-details/order-inventory-management-api/page.tsx
+++ b/app/project-details/order-inventory-management-api/page.tsx
@@ -1,0 +1,10 @@
+import OrderInventoryManagementApi from "@/components/project-details/OrderInventoryManagementApi";
+
+export default function Page() {
+  return (
+    <main className="container mx-auto max-w-5xl px-4 py-12">
+      <OrderInventoryManagementApi />
+    </main>
+  );
+}
+

--- a/components/project-details/OrderInventoryManagementApi.tsx
+++ b/components/project-details/OrderInventoryManagementApi.tsx
@@ -1,0 +1,44 @@
+import ProjectOverview from "./ProjectOverview";
+import ProjectSection from "./ProjectSection";
+
+export default function OrderInventoryManagementApi() {
+  return (
+    <div className="space-y-12">
+      <ProjectOverview
+        imageSrc="/static/placeholders/next.png"
+        alt="Order & Inventory Management API screenshot"
+      >
+        <p>
+          <strong>Overview:</strong> Lightweight RESTful API built with ASP.NET Core
+          and PostgreSQL for managing products and orders with stock validation and
+          audit logging.
+        </p>
+        <p>
+          <strong>Tech Stack:</strong> ASP.NET Core, Entity Framework Core, PostgreSQL,
+          FluentValidation, Serilog, Swagger.
+        </p>
+      </ProjectOverview>
+
+      <ProjectSection title="Key Features">
+        <ul className="list-disc pl-6 space-y-2">
+          <li>Product catalog with soft deletes and basic filtering.</li>
+          <li>Inventory-aware order creation that validates stock levels.</li>
+          <li>Idempotent order endpoints to prevent duplicate submissions.</li>
+          <li>Audit logs and structured logging via Serilog.</li>
+          <li>OpenAPI documentation with Swagger UI.</li>
+        </ul>
+      </ProjectSection>
+
+      <ProjectSection title="Development Notes">
+        <p>
+          The API follows a clean architecture approach using repositories and services
+          to separate concerns. Data access is handled through Entity Framework Core
+          with PostgreSQL migrations. Input validation is enforced with
+          FluentValidation, and integration tests ensure critical flows such as order
+          placement remain reliable.
+        </p>
+      </ProjectSection>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add OrderInventoryManagementApi project details component
- expose order-inventory-management-api page

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a54bc0ddf08329b45ae9b297dc6e76