### PR TITLE
feat: support component based project details

### DIFF
--- a/app/project-details/[slug]/page.tsx
+++ b/app/project-details/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import { promises as fs } from "fs";
 import path from "path";
+import type { ComponentType } from "react";
 
 interface PageProps {
   params: Promise<{
@@ -9,11 +10,31 @@ interface PageProps {
 
 export default async function ProjectDetailPage({ params }: PageProps) {
   const { slug } = await params;
+
+  let Component: ComponentType | null = null;
+  try {
+    Component = (await import(`@/components/project-details/${slug}`)).default;
+  } catch {
+    Component = null;
+  }
+
+  if (Component) {
+    return (
+      <main className="container mx-auto max-w-5xl px-4 py-12">
+        <Component />
+      </main>
+    );
+  }
+
   const filePath = path.join(process.cwd(), "public", "project-details", `${slug}.html`);
-  let html = "";
 
   try {
-    html = await fs.readFile(filePath, "utf8");
+    const html = await fs.readFile(filePath, "utf8");
+    return (
+      <main className="container mx-auto max-w-5xl px-4 py-12">
+        <div dangerouslySetInnerHTML={{ __html: html }} />
+      </main>
+    );
   } catch {
     return (
       <main className="container mx-auto max-w-5xl px-4 py-12">
@@ -21,18 +42,26 @@ export default async function ProjectDetailPage({ params }: PageProps) {
       </main>
     );
   }
-
-  return (
-    <main className="container mx-auto max-w-5xl px-4 py-12">
-      <div dangerouslySetInnerHTML={{ __html: html }} />
-    </main>
-  );
 }
 
 export async function generateStaticParams() {
-  const dir = path.join(process.cwd(), "public", "project-details");
-  const files = await fs.readdir(dir);
-  return files
+  const htmlDir = path.join(process.cwd(), "public", "project-details");
+  const componentDir = path.join(process.cwd(), "components", "project-details");
+
+  const [htmlFiles, componentFiles] = await Promise.all([
+    fs.readdir(htmlDir).catch(() => []),
+    fs.readdir(componentDir).catch(() => []),
+  ]);
+
+  const htmlSlugs = htmlFiles
     .filter((file) => file.endsWith(".html"))
-    .map((file) => ({ slug: file.replace(/\.html$/, "") }));
+    .map((file) => file.replace(/\.html$/, ""));
+
+  const componentSlugs = componentFiles
+    .filter((file) => file.endsWith(".tsx") && !file.startsWith("Project"))
+    .map((file) => file.replace(/\.tsx$/, ""));
+
+  const slugs = Array.from(new Set([...htmlSlugs, ...componentSlugs]));
+
+  return slugs.map((slug) => ({ slug }));
 }


### PR DESCRIPTION
## Summary
- attempt dynamic import of project-specific components before loading HTML
- statically generate pages for component and HTML project details

## Testing
- `npx -y vitest` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a54bc98804832989ffb28b241fefb3