### PR TITLE
docs: guide and example for custom project details

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,7 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Custom project details pages
+
+To add a new project detail page using the reusable `ProjectTemplate`, see [docs/project-details.md](./docs/project-details.md) for step-by-step instructions on cloning the template, placing assets, registering the slug, and wiring up the `page.tsx` route.

--- a/app/project-details/example-project/page.tsx
+++ b/app/project-details/example-project/page.tsx
@@ -1,0 +1,9 @@
+import ExampleProject from "@/components/project-details/ExampleProject";
+
+export default function Page() {
+  return (
+    <main className="container mx-auto max-w-5xl px-4 py-12">
+      <ExampleProject />
+    </main>
+  );
+}

--- a/components/project-details/ExampleProject.tsx
+++ b/components/project-details/ExampleProject.tsx
@@ -1,0 +1,29 @@
+import ProjectOverview from "./ProjectOverview";
+import ProjectSection from "./ProjectSection";
+
+export default function ExampleProject() {
+  return (
+    <div className="space-y-12">
+      <ProjectOverview
+        imageSrc="/static/placeholders/next.png"
+        alt="Example project screenshot"
+      >
+        <p>
+          <strong>Overview:</strong> Replace this text with a short summary of
+          your project.
+        </p>
+        <p>
+          <strong>Collaborators:</strong> List collaborators here.
+        </p>
+      </ProjectOverview>
+
+      <ProjectSection title="Introduction">
+        <p>Introduce your project here.</p>
+      </ProjectSection>
+
+      <ProjectSection title="Rationale">
+        <p>Explain the rationale or motivation behind the project.</p>
+      </ProjectSection>
+    </div>
+  );
+}

--- a/docs/project-details.md
+++ b/docs/project-details.md
@@ -1,0 +1,61 @@
+# Creating Custom Project Detail Pages
+
+This guide explains how to add a new project detail page by cloning the provided `ProjectTemplate` and customizing the reusable sections.
+
+## 1. Clone the template
+
+1. Copy `components/project-details/ProjectTemplate.tsx` to a new file in the same folder. For example:
+   ```bash
+   cp components/project-details/ProjectTemplate.tsx components/project-details/MyProject.tsx
+   ```
+2. Rename the default exported function to match your project, e.g. `MyProject`.
+3. Update the `<ProjectOverview>` props (`imageSrc`, `alt`) and its children to describe your project.
+4. Edit or remove the `<ProjectSection>` blocks and fill them with your content.
+
+## 2. Add project assets
+
+Place screenshots or other static files inside `public/static`. You can organize images in sub‑folders if desired:
+
+```
+public/
+└── static/
+    └── my-project/
+        └── screenshot.png
+```
+
+Reference these assets in your `ProjectOverview` with a root‑relative path (e.g. `/static/my-project/screenshot.png`).
+
+## 3. Register the project
+
+Add an entry in `public/data/projects.json` so the project appears in listings. Include a unique `details` slug pointing to your page directory:
+
+```json
+{
+  "title": "My Project",
+  "image": "/static/my-project/screenshot.png",
+  "alt": "My Project screenshot",
+  "description": "Short summary…",
+  "tags": ["Tag1", "Tag2"],
+  "details": "project-details/my-project"
+}
+```
+
+## 4. Create the page route
+
+Create a folder under `app/project-details/<slug>/` and add a `page.tsx` that imports your customized component:
+
+```tsx
+import MyProject from "@/components/project-details/MyProject";
+
+export default function Page() {
+  return (
+    <main className="container mx-auto max-w-5xl px-4 py-12">
+      <MyProject />
+    </main>
+  );
+}
+```
+
+The `<slug>` directory must match the `details` field in `public/data/projects.json`.
+
+With these steps your new project detail page will be served at `/project-details/<slug>`.


### PR DESCRIPTION
## Summary
- document how to clone `ProjectTemplate`, customize sections, and wire up page routes
- link README to detailed project details guide
- add example component and page demonstrating how to import custom project details

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a54bca6dd08329af7ec3bc6f10c544