### PR TITLE
fix: use images prop in BudgetSystem overview

### DIFF
--- a/components/project-details/BudgetSystem.tsx
+++ b/components/project-details/BudgetSystem.tsx
@@ -5,7 +5,7 @@ export default function BudgetSystem() {
   return (
     <div className="space-y-12">
       <ProjectOverview
-        imageSrc="/static/placeholders/next.png"
+        images={["/static/placeholders/next.png"]}
         alt="Budget System screenshot"
       >
         <p>

--- a/docs/project-details.md
+++ b/docs/project-details.md
@@ -9,7 +9,7 @@ This guide explains how to add a new project detail page by cloning the provided
    cp components/project-details/ProjectTemplate.tsx components/project-details/MyProject.tsx
    ```
 2. Rename the default exported function to match your project, e.g. `MyProject`.
-3. Update the `<ProjectOverview>` props (`imageSrc`, `alt`) and its children to describe your project.
+3. Update the `<ProjectOverview>` props (`images`, `alt`) and its children to describe your project.
 4. Edit or remove the `<ProjectSection>` blocks and fill them with your content.
 
 ## 2. Add project assets
@@ -23,7 +23,7 @@ public/
         └── screenshot.png
 ```
 
-Reference these assets in your `ProjectOverview` with a root‑relative path (e.g. `/static/my-project/screenshot.png`).
+Reference these assets in your `ProjectOverview` using the `images` prop with root‑relative paths (e.g. `/static/my-project/screenshot.png`).
 
 ## 3. Register the project
 


### PR DESCRIPTION
## Summary
- fix BudgetSystem project details to use `images` prop instead of deprecated `imageSrc`
- clarify project details docs to reference `images` prop

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jsdom)*
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm run build` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5abceac4083298d0b46d680afe9bd