### PR TITLE
feat: wire project images and galleries

### DIFF
--- a/components/project-details/AICoinDetector.tsx
+++ b/components/project-details/AICoinDetector.tsx
@@ -1,10 +1,12 @@
 import ProjectOverview from "./ProjectOverview";
+import { getProjectImages } from "@/lib/project-images";
 
-export default function AICoinDetector() {
+export default async function AICoinDetector() {
+  const images = await getProjectImages("ai-coin-detector");
   return (
     <div className="space-y-12">
       <ProjectOverview
-        images={["/static/placeholders/ai.png"]}
+        images={images.length ? images : ["/static/placeholders/ai.png"]}
         alt="AI Coin Detector Screenshot"
         githubUrl="https://github.com/Seanneskie/AI-coin-detector-django"
       >

--- a/components/project-details/BudgetSystem.tsx
+++ b/components/project-details/BudgetSystem.tsx
@@ -1,11 +1,13 @@
 import ProjectOverview from "./ProjectOverview";
 import ProjectSection from "./ProjectSection";
+import { getProjectImages } from "@/lib/project-images";
 
-export default function BudgetSystem() {
+export default async function BudgetSystem() {
+  const images = await getProjectImages("budget-system");
   return (
     <div className="space-y-12">
       <ProjectOverview
-        images={["/static/placeholders/next.png"]}
+        images={images.length ? images : ["/static/placeholders/next.png"]}
         alt="Budget System screenshot"
       >
         <p>

--- a/components/project-details/OrderInventoryManagementApi.tsx
+++ b/components/project-details/OrderInventoryManagementApi.tsx
@@ -1,11 +1,13 @@
 import ProjectOverview from "./ProjectOverview";
 import ProjectSection from "./ProjectSection";
+import { getProjectImages } from "@/lib/project-images";
 
-export default function OrderInventoryManagementApi() {
+export default async function OrderInventoryManagementApi() {
+  const images = await getProjectImages("order-inventory-management-api");
   return (
     <div className="space-y-12">
       <ProjectOverview
-        images={["/static/placeholders/next.png"]}
+        images={images.length ? images : ["/static/placeholders/next.png"]}
         alt="Order & Inventory Management API screenshot"
       >
         <p>

--- a/components/project-details/ProjectHtml.tsx
+++ b/components/project-details/ProjectHtml.tsx
@@ -1,11 +1,14 @@
 import { promises as fs } from "fs";
 import path from "path";
+import ProjectGallery from "./ProjectGallery";
+import { getProjectImages } from "@/lib/project-images";
 
 interface ProjectHtmlProps {
   slug: string;
 }
 
 export default async function ProjectHtml({ slug }: ProjectHtmlProps) {
+  const images = await getProjectImages(slug);
   const filePath = path.join(process.cwd(), "public", "project-details", `${slug}.html`);
 
   let html = "";
@@ -15,5 +18,12 @@ export default async function ProjectHtml({ slug }: ProjectHtmlProps) {
     html = "<p>Project details not found.</p>";
   }
 
-  return <div dangerouslySetInnerHTML={{ __html: html }} />;
+  return (
+    <div className="space-y-6">
+      {images.length > 0 && (
+        <ProjectGallery images={images} alt={`${slug} screenshot`} />
+      )}
+      <div dangerouslySetInnerHTML={{ __html: html }} />
+    </div>
+  );
 }

--- a/lib/project-images.ts
+++ b/lib/project-images.ts
@@ -1,0 +1,16 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+export async function getProjectImages(slug: string): Promise<string[]> {
+  try {
+    const jsonPath = path.join(process.cwd(), 'public', slug, 'images', 'images.json');
+    const data = await fs.readFile(jsonPath, 'utf8');
+    const names = JSON.parse(data) as string[];
+    if (!Array.isArray(names) || names.length === 0) {
+      return [];
+    }
+    return names.map((name) => `/${slug}/images/${name}`);
+  } catch {
+    return [];
+  }
+}

--- a/public/data/projects.json
+++ b/public/data/projects.json
@@ -68,7 +68,7 @@
   },
   {
     "title": "Bitcoin Analysis App",
-    "image": "/static/placeholders/django.png",
+    "image": "/bitcoin-analysis-app/images/1.png",
     "alt": "Analysis Image",
     "description": "A Bitcoin Prediction and Descriptive Analysis. Made with Django and Python Modules.",
     "tags": [
@@ -87,12 +87,20 @@
     "details": "project-details/bitcoin-analysis-app",
     "period": "Nov 2024 - Dec 2025",
     "images": [
-      "/static/placeholders/django.png"
+      "/bitcoin-analysis-app/images/1.png",
+      "/bitcoin-analysis-app/images/2.png",
+      "/bitcoin-analysis-app/images/3.png",
+      "/bitcoin-analysis-app/images/4.png",
+      "/bitcoin-analysis-app/images/5.png",
+      "/bitcoin-analysis-app/images/6.png",
+      "/bitcoin-analysis-app/images/7.png",
+      "/bitcoin-analysis-app/images/8.png",
+      "/bitcoin-analysis-app/images/9.png"
     ]
   },
   {
     "title": "Desktop Payroll Management System",
-    "image": "/static/placeholders/python-default.png",
+    "image": "/pms/images/1.png",
     "alt": "Desktop Payroll Management System Image",
     "description": "FastAPI-powered payroll management backend bundled with an Electron desktop shell.",
     "tags": [
@@ -108,12 +116,16 @@
     "details": "project-details/pms",
     "period": "Aug 2025 - Present",
     "images": [
-      "/static/placeholders/python-default.png"
+      "/pms/images/1.png",
+      "/pms/images/2.png",
+      "/pms/images/3.png",
+      "/pms/images/4.png",
+      "/pms/images/5.png"
     ]
   },
   {
     "title": "Digital Freelancer Profiling App",
-    "image": "/static/placeholders/django.png",
+    "image": "/digital-freelancer-profiling-app/images/1.png",
     "alt": "Coin Detector Image",
     "description": "A Digital Freelancer Profiling System for Capstone requirement. Made with Django and Python Modules.",
     "collaborators": "Kimberly Baylon, Bridget Jose, Azlan Tomindug",
@@ -130,7 +142,16 @@
     "details": "project-details/digital-freelancer-profiling-app",
     "period": "Jan 2024 - May 2025",
     "images": [
-      "/static/placeholders/django.png"
+      "/digital-freelancer-profiling-app/images/1.png",
+      "/digital-freelancer-profiling-app/images/2.png",
+      "/digital-freelancer-profiling-app/images/3.png",
+      "/digital-freelancer-profiling-app/images/4.png",
+      "/digital-freelancer-profiling-app/images/5.png",
+      "/digital-freelancer-profiling-app/images/6.png",
+      "/digital-freelancer-profiling-app/images/7.png",
+      "/digital-freelancer-profiling-app/images/8.png",
+      "/digital-freelancer-profiling-app/images/9.PNG",
+      "/digital-freelancer-profiling-app/images/10.png"
     ]
   },
   {
@@ -203,7 +224,7 @@
   },
   {
     "title": "Albany Airbnb Dashboard",
-    "image": "/static/placeholders/django.png",
+    "image": "/albany-airbnb-dashboard/images/1.png",
     "alt": "Albany Airbnb Dashboard Image",
     "description": "Interactive dashboard analyzing Airbnb listings, pricing, and guest sentiment.",
     "tags": [
@@ -223,7 +244,11 @@
     "details": "project-details/albany-airbnb-dashboard",
     "period": "Nov 2024 - Dec 2024",
     "images": [
-      "/static/placeholders/django.png"
+      "/albany-airbnb-dashboard/images/1.png",
+      "/albany-airbnb-dashboard/images/2.png",
+      "/albany-airbnb-dashboard/images/3.png",
+      "/albany-airbnb-dashboard/images/4.png",
+      "/albany-airbnb-dashboard/images/5.png"
     ]
   },
   {
@@ -311,7 +336,7 @@
     "githubLabel": "View on GitHub",
     "details": "project-details/order-inventory-management-api",
     "period": "Aug 2025 - Aug 2025",
-     "images": [
+    "images": [
       "/static/placeholders/next.png"
     ]
   },

--- a/public/digital-freelancer-profiling-app/images/images.json
+++ b/public/digital-freelancer-profiling-app/images/images.json
@@ -1,1 +1,1 @@
-["1.png", "2.png", "3.png", "4.png", "5.png", "6.png", "7.png", "8.png", "9.png", "10"]
+["1.png", "2.png", "3.png", "4.png", "5.png", "6.png", "7.png", "8.png", "9.PNG", "10.png"]


### PR DESCRIPTION
## Summary
- load project image sets from `public/<slug>/images` via new helper
- show project screenshots in details pages with gallery support
- link project list to real screenshots instead of placeholders

## Testing
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b0085d608329b84ec71da111605a