### PR TITLE
Allow project card descriptions to expand

### DIFF
--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -134,7 +134,7 @@ export default function ProjectsPage() {
             >
               <Card
                 className={[
-                  "group relative h-[460px] overflow-hidden rounded-2xl p-4",
+                  "group relative min-h-[460px] overflow-hidden rounded-2xl p-4",
                   "border border-teal-200/70 bg-white/85 backdrop-blur",
                   "dark:border-teal-800/70 dark:bg-gray-950/60",
                   "transition-shadow hover:shadow-lg hover:shadow-teal-300/30 dark:hover:shadow-teal-900/20",
@@ -158,7 +158,7 @@ export default function ProjectsPage() {
                 </h3>
 
                 {p.description ? (
-                  <p className="mt-1 line-clamp-3 text-sm text-gray-700 dark:text-gray-200">
+                  <p className="mt-1 text-sm text-gray-700 dark:text-gray-200">
                     {p.description}
                   </p>
                 ) : null}


### PR DESCRIPTION
## Summary
- Remove strict height on project cards so they can grow with content
- Show full project descriptions instead of clamping to three lines

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d537f62c8329804e8418426dbd6d