### PR TITLE
feat: add download button for AI project pdf

### DIFF
--- a/components/project-details/AICoinDetector.tsx
+++ b/components/project-details/AICoinDetector.tsx
@@ -16,6 +16,7 @@ export default async function AICoinDetector() {
         images={images.length ? images : ["/static/placeholders/ai.png"]}
         alt="AI Coin Detector Screenshot"
         githubUrl="https://github.com/Seanneskie/AI-coin-detector-django"
+        downloadUrl="/ai-coin-detector/pdfs/Philippine%20Peso%20Coin%20Detector%20and%20Counter.pdf"
       >
         <p>
           <strong>Overview:</strong> This AI Coin Detector was developed using

--- a/components/project-details/ProjectOverview.tsx
+++ b/components/project-details/ProjectOverview.tsx
@@ -3,6 +3,8 @@ import Link from "next/link";
 import { ReactNode } from "react";
 import { withBasePath } from "@/lib/utils";
 import ProjectGallery from "./ProjectGallery";
+import { Button } from "@/components/ui/button";
+import { FileText } from "lucide-react";
 
 interface ProjectOverviewProps {
   images: string[];
@@ -51,13 +53,12 @@ export default function ProjectOverview({
           </Link>
         )}
         {downloadUrl && (
-          <Link
-            href={withBasePath(downloadUrl)}
-            download
-            className="inline-block underline"
-          >
-            Download
-          </Link>
+          <Button variant="outline" size="sm" asChild className="gap-2">
+            <a href={withBasePath(downloadUrl)} download>
+              <FileText className="h-4 w-4" />
+              Download
+            </a>
+          </Button>
         )}
       </div>
     </section>


### PR DESCRIPTION
## Summary
- add download support to ProjectOverview with button styling
- link AI Coin Detector project to downloadable PDF

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d77b544083299b3e6c1c21280bd2