### PR TITLE
fix: escape apostrophes in project details

### DIFF
--- a/components/project-details/AiPoweredEmailGenerator.tsx
+++ b/components/project-details/AiPoweredEmailGenerator.tsx
@@ -25,7 +25,7 @@ export default async function AiPoweredEmailGenerator() {
 
       <ProjectSection title="LangChain Prompts">
         <p>
-          Prompts are assembled with LangChain's
+          Prompts are assembled with LangChain&apos;s
           <code> ChatPromptTemplate </code> to capture the desired tone, audience,
           and key points. Few-shot examples guide the model toward concise
           and professional language.

--- a/components/project-details/BitcoinAnalysisApp.tsx
+++ b/components/project-details/BitcoinAnalysisApp.tsx
@@ -11,7 +11,7 @@ export default async function BitcoinAnalysisApp() {
         alt="Bitcoin Analysis App screenshot"
       >
         <p>
-          <strong>Overview:</strong> The Bitcoin Analysis App explores Bitcoin's
+          <strong>Overview:</strong> The Bitcoin Analysis App explores Bitcoin&apos;s
           historical price movement and market activity through interactive
           visualizations.
         </p>

--- a/components/project-details/HeadlessEcommerceMiniStore.tsx
+++ b/components/project-details/HeadlessEcommerceMiniStore.tsx
@@ -23,14 +23,14 @@ export default async function HeadlessEcommerceMiniStore() {
       </ProjectOverview>
       <ProjectSection title="Product Catalog">
         <p>
-          The storefront queries Shopify's GraphQL API to display products,
+          The storefront queries Shopify&apos;s GraphQL API to display products,
           collections, and real-time inventory with a responsive UI.
         </p>
       </ProjectSection>
       <ProjectSection title="Checkout Flow">
         <p>
           Customers proceed through a custom checkout that hands off to
-          Shopify's secure checkout while persisting cart data via serverless
+          Shopify&apos;s secure checkout while persisting cart data via serverless
           functions.
         </p>
       </ProjectSection>

--- a/components/project-details/McdonaldsSentimentAnalysis.tsx
+++ b/components/project-details/McdonaldsSentimentAnalysis.tsx
@@ -8,11 +8,11 @@ export default async function McdonaldsSentimentAnalysis() {
     <div className="space-y-12">
       <ProjectOverview
         images={images.length ? images : ["/static/placeholders/django.png"]}
-        alt="McDonald's Sentiment Analysis screenshot"
+        alt="McDonald&apos;s Sentiment Analysis screenshot"
       >
         <p>
           <strong>Overview:</strong> Sentiment analysis of over 33,000
-          McDonald's Google reviews using Python to understand customer
+          McDonald&apos;s Google reviews using Python to understand customer
           satisfaction trends.
         </p>
         <p>
@@ -23,7 +23,7 @@ export default async function McdonaldsSentimentAnalysis() {
       <ProjectSection title="Dataset">
         <p>
           The dataset contains more than 33,000 reviews scraped from Google
-          Maps. Each review includes the user's rating, review text, and date,
+          Maps. Each review includes the user&apos;s rating, review text, and date,
           providing a rich corpus for sentiment analysis.
         </p>
       </ProjectSection>


### PR DESCRIPTION
## Summary
- escape apostrophes in project descriptions to satisfy `react/no-unescaped-entities`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a96a43a51c83299d23c28468c21673