### PR TITLE
feat: fetch project images in project template

### DIFF
--- a/components/project-details/ProjectTemplate.tsx
+++ b/components/project-details/ProjectTemplate.tsx
@@ -1,12 +1,16 @@
 import ProjectOverview from "./ProjectOverview";
 import ProjectSection from "./ProjectSection";
-
-export default function ProjectTemplate() {
+import ProjectGallery from "./ProjectGallery";
+import { getProjectImages } from "@/lib/project-images";
+export default async function ProjectTemplate() {
+  const images = await getProjectImages("project-slug");
   return (
     <div className="space-y-12">
       <ProjectOverview
-        images={["/static/placeholders/ai.png"]}
+        images={images.length ? images : ["/static/placeholders/ai.png"]}
         alt="Project screenshot"
+        // githubUrl="https://github.com/username/repo" // optional
+        // downloadUrl="/static/project-slug/file.zip" // optional
       >
         <p>
           <strong>Overview:</strong> Brief overview of the project.
@@ -43,6 +47,12 @@ export default function ProjectTemplate() {
       <ProjectSection title="Ethical and Societal Implications">
         <p>Share ethical and societal considerations.</p>
       </ProjectSection>
+
+      {images.length > 0 && (
+        <ProjectSection title="Screenshots">
+          <ProjectGallery images={images} alt="Project screenshot" />
+        </ProjectSection>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- load template images with `getProjectImages` and show `ProjectGallery`
- document optional `githubUrl` and `downloadUrl` support in `ProjectOverview`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a96a9950788329bf48ced7732b26b1