### PR TITLE
refactor: simplify project detail routing

### DIFF
--- a/app/project-details/[slug]/page.tsx
+++ b/app/project-details/[slug]/page.tsx
@@ -3,9 +3,9 @@ import path from "path";
 import type { ComponentType } from "react";
 
 interface PageProps {
-  params: Promise<{
+  params: {
     slug: string;
-  }>;
+  };
 }
 
 const componentMap: Record<string, () => Promise<{ default: ComponentType }>> = {
@@ -30,11 +30,10 @@ const componentMap: Record<string, () => Promise<{ default: ComponentType }>> = 
   "order-inventory-management-api": () =>
     import("@/components/project-details/OrderInventoryManagementApi"),
   "budget-system": () => import("@/components/project-details/BudgetSystem"),
-  "example-project": () => import("@/components/project-details/ExampleProject"),
 };
 
 export default async function ProjectDetailPage({ params }: PageProps) {
-  const { slug } = await params;
+  const { slug } = params;
 
   let Component: ComponentType | null = null;
 


### PR DESCRIPTION
## Summary
- streamline dynamic project detail page to use slug directly
- remove leftover example project entry to keep routing data in sync

## Testing
- `npm run lint` *(fails: next not found, dependencies missing)*
- `npm test` *(fails: vitest not found, dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a971caad008329af6bc5b09b235011