### PR TITLE
fix: adjust project detail params type

### DIFF
--- a/app/project-details/[slug]/page.tsx
+++ b/app/project-details/[slug]/page.tsx
@@ -3,9 +3,7 @@ import path from "path";
 import type { ComponentType } from "react";
 
 interface PageProps {
-  params: {
-    slug: string;
-  };
+  params: Promise<{ slug: string }>;
 }
 
 const componentMap: Record<string, () => Promise<{ default: ComponentType }>> = {
@@ -34,7 +32,7 @@ const componentMap: Record<string, () => Promise<{ default: ComponentType }>> = 
 };
 
 export default async function ProjectDetailPage({ params }: PageProps) {
-  const { slug } = params;
+  const { slug } = await params;
 
   let Component: ComponentType | null = null;
 


### PR DESCRIPTION
## Summary
- fix project detail slug page params type for Next.js 15

## Testing
- `npm ci` (fails: 403 Forbidden - jsdom)
- `npm run lint` (fails: next not found)
- `npm test` (fails: vitest not found)

------
https://chatgpt.com/codex/tasks/task_e_68a98259a4508329bc8e02abf5c694ff