### PR TITLE
Add titles to project overview and details

### DIFF
--- a/components/project-details/AICoinDetector.tsx
+++ b/components/project-details/AICoinDetector.tsx
@@ -8,6 +8,7 @@ export default async function AICoinDetector() {
   return (
     <div className="space-y-12">
       <ProjectOverview
+        title="AI Coin Detector"
         images={images.length ? images : ["/static/placeholders/ai.png"]}
         alt="AI Coin Detector Screenshot"
         githubUrl="https://github.com/Seanneskie/AI-coin-detector-django"

--- a/components/project-details/AiPoweredEmailGenerator.tsx
+++ b/components/project-details/AiPoweredEmailGenerator.tsx
@@ -8,6 +8,7 @@ export default async function AiPoweredEmailGenerator() {
   return (
     <div className="space-y-12">
       <ProjectOverview
+        title="AI-Powered Email Generator"
         images={images.length ? images : ["/static/placeholders/ai.png"]}
         alt="AI Powered Email Generator screenshot"
         githubUrl="https://github.com/Seanneskie/ai-powered-email-generator"

--- a/components/project-details/AlbanyAirbnbDashboard.tsx
+++ b/components/project-details/AlbanyAirbnbDashboard.tsx
@@ -8,6 +8,7 @@ export default async function AlbanyAirbnbDashboard() {
   return (
     <div className="space-y-12">
       <ProjectOverview
+        title="Albany Airbnb Dashboard"
         images={images.length ? images : ["/static/placeholders/data-analytics.webp"]}
         alt="Albany Airbnb Dashboard screenshot"
       >

--- a/components/project-details/BitcoinAnalysisApp.tsx
+++ b/components/project-details/BitcoinAnalysisApp.tsx
@@ -8,6 +8,7 @@ export default async function BitcoinAnalysisApp() {
   return (
     <div className="space-y-12">
       <ProjectOverview
+        title="Bitcoin Analysis App"
         images={
           images.length ? images : ["/static/placeholders/data-analytics.webp"]
         }

--- a/components/project-details/BudgetSystem.tsx
+++ b/components/project-details/BudgetSystem.tsx
@@ -8,6 +8,7 @@ export default async function BudgetSystem() {
   return (
     <div className="space-y-12">
       <ProjectOverview
+        title="Budget System"
         images={images.length ? images : ["/static/placeholders/next.png"]}
         alt="Budget System screenshot"
       >

--- a/components/project-details/CemcdoApp.tsx
+++ b/components/project-details/CemcdoApp.tsx
@@ -8,6 +8,7 @@ export default async function CemcdoApp() {
   return (
     <div className="space-y-12">
       <ProjectOverview
+        title="CEMCDO App"
         images={images.length ? images : ["/static/placeholders/django.png"]}
         alt="CEMCDO App screenshot"
         githubUrl="https://cemcdo-demo.onrender.com/"

--- a/components/project-details/CnsmWebsite.tsx
+++ b/components/project-details/CnsmWebsite.tsx
@@ -8,6 +8,7 @@ export default async function CnsmWebsite() {
   return (
     <div className="space-y-12">
       <ProjectOverview
+        title="CNSM Website"
         images={images.length ? images : ["/static/placeholders/Mern.png"]}
         alt="CNSM website screenshot"
         githubUrl="https://github.com/Seanneskie/advDB-CNSM-Website"

--- a/components/project-details/DesktopPayrollManagementSystem.tsx
+++ b/components/project-details/DesktopPayrollManagementSystem.tsx
@@ -10,6 +10,7 @@ export default async function DesktopPayrollManagementSystem() {
   return (
     <div className="space-y-12">
       <ProjectOverview
+        title="Desktop Payroll Management System"
         images={images.length ? images : ["/static/placeholders/next.png"]}
         alt="Desktop Payroll Management System screenshot"
       >

--- a/components/project-details/DigitalFreelancerProfilingApp.tsx
+++ b/components/project-details/DigitalFreelancerProfilingApp.tsx
@@ -8,6 +8,7 @@ export default async function DigitalFreelancerProfilingApp() {
   return (
     <div className="space-y-12">
       <ProjectOverview
+        title="Digital Freelancer Profiling App"
         images={images.length ? images : ["/static/placeholders/next.png"]}
         alt="Digital Freelancer Profiling App screenshot"
         downloadUrl="/digital-freelancer-profiling-app/pdfs/DPFS_UserManual.pdf"

--- a/components/project-details/ExampleProject.tsx
+++ b/components/project-details/ExampleProject.tsx
@@ -8,6 +8,7 @@ export default async function ExampleProject() {
   return (
     <div className="space-y-12">
       <ProjectOverview
+        title="Example Project"
         images={images.length ? images : ["/static/placeholders/ai.png"]}
         alt="Example project screenshot"
       >

--- a/components/project-details/HeadlessEcommerceMiniStore.tsx
+++ b/components/project-details/HeadlessEcommerceMiniStore.tsx
@@ -10,6 +10,7 @@ export default async function HeadlessEcommerceMiniStore() {
   return (
     <div className="space-y-12">
       <ProjectOverview
+        title="Headless E-Commerce Mini-Store"
         images={images.length ? images : fallback}
         alt="Headless E-Commerce Mini-Store screenshot"
       >

--- a/components/project-details/ItineraryPlanner.tsx
+++ b/components/project-details/ItineraryPlanner.tsx
@@ -8,6 +8,7 @@ export default async function ItineraryPlanner() {
   return (
     <div className="space-y-12">
       <ProjectOverview
+        title="Itinerary Planner"
         images={images.length ? images : ["/static/placeholders/data-analytics.webp"]}
         alt="Itinerary Planner screenshot"
       >

--- a/components/project-details/McdonaldsSentimentAnalysis.tsx
+++ b/components/project-details/McdonaldsSentimentAnalysis.tsx
@@ -8,6 +8,7 @@ export default async function McdonaldsSentimentAnalysis() {
   return (
     <div className="space-y-12">
       <ProjectOverview
+        title="McDonald's Sentiment Analysis"
         images={images.length ? images : ["/static/placeholders/django.png"]}
         alt="McDonald&apos;s Sentiment Analysis screenshot"
       >

--- a/components/project-details/NosqlProject.tsx
+++ b/components/project-details/NosqlProject.tsx
@@ -8,6 +8,7 @@ export default async function NosqlProject() {
   return (
     <div className="space-y-12">
       <ProjectOverview
+        title="NoSQL Project - MERN Stack Website"
         images={images.length ? images : ["/static/placeholders/Mern.png"]}
         alt="NoSQL Project screenshot"
       >

--- a/components/project-details/OrderInventoryManagementApi.tsx
+++ b/components/project-details/OrderInventoryManagementApi.tsx
@@ -8,6 +8,7 @@ export default async function OrderInventoryManagementApi() {
   return (
     <div className="space-y-12">
       <ProjectOverview
+        title="Order & Inventory Management API"
         images={images.length ? images : ["/static/placeholders/next.png"]}
         alt="Order & Inventory Management API screenshot"
       >

--- a/components/project-details/ProjectOverview.tsx
+++ b/components/project-details/ProjectOverview.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { FileText, Github } from "lucide-react";
 
 interface ProjectOverviewProps {
+  title: string;
   images: string[];
   alt: string;
   children: ReactNode;
@@ -16,6 +17,7 @@ interface ProjectOverviewProps {
 }
 
 export default function ProjectOverview({
+  title,
   images,
   alt,
   children,
@@ -45,6 +47,9 @@ export default function ProjectOverview({
         )}
       </div>
       <div className="space-y-2">
+        <h1 className="text-3xl font-bold tracking-tight text-teal-700 dark:text-teal-400">
+          {title}
+        </h1>
         {children}
         {(githubUrl || downloadUrl) && (
           <div className="flex flex-wrap gap-2 pt-1">

--- a/components/project-details/ProjectTemplate.tsx
+++ b/components/project-details/ProjectTemplate.tsx
@@ -7,6 +7,7 @@ export default async function ProjectTemplate() {
   return (
     <div className="space-y-12">
       <ProjectOverview
+        title="Project Title"
         images={images.length ? images : ["/static/placeholders/ai.png"]}
         alt="Project screenshot"
         // githubUrl="https://github.com/username/repo" // optional

--- a/components/project-details/Vims.tsx
+++ b/components/project-details/Vims.tsx
@@ -8,6 +8,7 @@ export default async function Vims() {
   return (
     <div className="space-y-12">
       <ProjectOverview
+        title="Vessel Inventory Management System"
         images={images.length ? images : ["/static/placeholders/next.png"]}
         alt="Vessel Inventory Management System screenshot"
       >

--- a/docs/project-details.md
+++ b/docs/project-details.md
@@ -9,7 +9,7 @@ This guide explains how to add a new project detail page by cloning the provided
    cp components/project-details/ProjectTemplate.tsx components/project-details/MyProject.tsx
    ```
 2. Rename the default exported function to match your project, e.g. `MyProject`.
-3. Update the `<ProjectOverview>` props (`images`, `alt`) and its children to describe your project.
+3. Update the `<ProjectOverview>` props (`title`, `images`, `alt`) and its children to describe your project.
 4. Edit or remove the `<ProjectSection>` blocks and fill them with your content.
 
 ## 2. Add project assets


### PR DESCRIPTION
## Summary
- include a required `title` prop in `ProjectOverview` and display it as a heading
- provide titles for all project detail components and update the template and docs

## Testing
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa567e322c83299fb3e14ff51dcaba