### PR TITLE
refactor: extract project tag filter component

### DIFF
--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -10,6 +10,7 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import TagFilter from "@/components/projects/tag-filter";
 import { useData } from "@/lib/use-data";
 
 interface Project {
@@ -60,13 +61,6 @@ export default function ProjectsPage() {
     page * ITEMS_PER_PAGE
   );
 
-  const toggleTag = (tag: string) => {
-    setPage(1);
-    setSelectedTags((prev) =>
-      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag]
-    );
-  };
-
   const handleSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
     setPage(1);
     setSearch(e.target.value);
@@ -107,18 +101,14 @@ export default function ProjectsPage() {
           onChange={handleSearch}
           className="w-full"
         />
-        <div className="flex flex-wrap gap-2">
-          {allTags.map((tag) => (
-            <Button
-              key={tag}
-              variant={selectedTags.includes(tag) ? "default" : "outline"}
-              size="sm"
-              onClick={() => toggleTag(tag)}
-            >
-              {tag}
-            </Button>
-          ))}
-        </div>
+        <TagFilter
+          tags={allTags}
+          selected={selectedTags}
+          onChange={(tags) => {
+            setSelectedTags(tags);
+            setPage(1);
+          }}
+        />
       </div>
 
       {currentProjects.length === 0 ? (

--- a/components/projects/tag-filter.tsx
+++ b/components/projects/tag-filter.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+interface TagFilterProps {
+  tags: string[];
+  selected: string[];
+  onChange: (tags: string[]) => void;
+  className?: string;
+}
+
+export default function TagFilter({
+  tags,
+  selected,
+  onChange,
+  className,
+}: TagFilterProps) {
+  const toggleTag = (tag: string) => {
+    onChange(
+      selected.includes(tag)
+        ? selected.filter((t) => t !== tag)
+        : [...selected, tag]
+    );
+  };
+
+  return (
+    <div className={cn("flex flex-wrap gap-2", className)}>
+      {tags.map((tag) => {
+        const isSelected = selected.includes(tag);
+        return (
+          <Badge
+            key={tag}
+            onClick={() => toggleTag(tag)}
+            className={cn(
+              "cursor-pointer select-none",
+              isSelected
+                ? "bg-teal-600 text-white"
+                : "bg-teal-50 text-teal-800 ring-1 ring-inset ring-teal-200 dark:bg-teal-900/30 dark:text-teal-200 dark:ring-teal-800"
+            )}
+          >
+            {tag}
+          </Badge>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- extract project tag filter logic into reusable component
- convert project filter to multi-chip selector

## Testing
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa3cb0bc88329a15fc8920e1677dc