### PR TITLE
refactor: move VIMS tech stack to dedicated section

### DIFF
--- a/components/project-details/Vims.tsx
+++ b/components/project-details/Vims.tsx
@@ -19,9 +19,9 @@ export default async function Vims() {
           requests and report generation, with a responsive interface styled by
           Tailwind CSS and Radix UI components.
         </p>
-        <p>
-          <strong>Tech Stack:</strong>
-        </p>
+      </ProjectOverview>
+
+      <ProjectSection title="Tech Stack">
         <ul className="list-disc list-inside space-y-1">
           <li>
             <strong>Framework:</strong> Next.js 15 with React 18 and TypeScript,
@@ -48,7 +48,7 @@ export default async function Vims() {
             alerts
           </li>
         </ul>
-      </ProjectOverview>
+      </ProjectSection>
 
       <ProjectSection title="Introduction">
         <p>


### PR DESCRIPTION
## Summary
- move tech stack list for VIMS project into its own section

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aabddbc8708329b183645fca798e76