### PR TITLE
docs: note Scrumban workflow in freelancer app

### DIFF
--- a/components/project-details/DigitalFreelancerProfilingApp.tsx
+++ b/components/project-details/DigitalFreelancerProfilingApp.tsx
@@ -35,6 +35,10 @@ export default async function DigitalFreelancerProfilingApp() {
           with features for profile creation, event participation, announcements,
           and support ticket handling.
         </p>
+        <p>
+          Development tasks were tracked in Notion using Kanban boards tailored
+          to a Scrumban workflow.
+        </p>
       </ProjectSection>
       <ProjectSection title="Features">
         <ul className="list-disc pl-6 space-y-1">
@@ -52,6 +56,10 @@ export default async function DigitalFreelancerProfilingApp() {
           </li>
           <li>
             Admin dashboard with analytics and content management.
+          </li>
+          <li>
+            Organize work in Notion Kanban boards with Scrumban for iterative
+            planning and review.
           </li>
         </ul>
       </ProjectSection>

--- a/public/data/projects.json
+++ b/public/data/projects.json
@@ -130,7 +130,7 @@
     "title": "Digital Freelancer Profiling App",
     "image": "/digital-freelancer-profiling-app/images/1.png",
     "alt": "Coin Detector Image",
-    "description": "A Digital Freelancer Profiling System for Capstone requirement. Made with Django and Python Modules.",
+    "description": "A Digital Freelancer Profiling System for Capstone requirement. Made with Django and Python Modules, featuring Notion Kanban boards that follow a Scrumban workflow for task management.",
     "collaborators": "Kimberly Baylon, Bridget Jose, Azlan Tomindug",
     "tags": [
       "Django",


### PR DESCRIPTION
## Summary
- mention Notion-based Kanban boards following Scrumban in Digital Freelancer Profiling App overview
- highlight Notion Kanban and Scrumban workflow in project catalog description

## Testing
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aac69b3a8c832989f3504426ce2c5b