### PR TITLE
feat: expand core skills while retaining previous data

### DIFF
--- a/public/data/skills.json
+++ b/public/data/skills.json
@@ -4,54 +4,117 @@
     "label": "Programming",
     "groups": [
       {
-        "title": "Programming",
-        "items": [
-          {"icon": "devicon-python-plain colored", "name": "Python"},
-          {"icon": "devicon-javascript-plain colored", "name": "JavaScript"},
-          {"icon": "devicon-php-plain colored", "name": "PHP"},
-          {"icon": "devicon-typescript-plain colored", "name": "TypeScript"}
-        ]
-      },
-      {
         "title": "Web Development",
         "items": [
-          {"icon": "devicon-html5-plain colored", "name": "HTML"},
-          {"icon": "devicon-css3-plain colored", "name": "CSS"},
-          {"icon": "devicon-bootstrap-plain colored", "name": "Bootstrap 4.0 and 5.0"},
+          {"icon": "devicon-django-plain colored", "name": "Django"},
+          {"icon": "devicon-laravel-plain colored", "name": "Laravel 12"},
+          {"icon": "devicon-alpinejs-original colored", "name": "Alpine.js"},
+          {"icon": "devicon-vitejs-plain colored", "name": "Vite"},
+          {"icon": "devicon-react-original colored", "name": "ReactJS"},
+          {"icon": "devicon-nextjs-plain", "name": "NextJS"},
+          {"icon": "devicon-php-plain colored", "name": "PHP (Basic)"},
+          {"icon": "devicon-typescript-plain colored", "name": "TypeScript"},
+          {"icon": "devicon-javascript-plain colored", "name": "JavaScript"},
+          {"icon": "devicon-jquery-plain colored", "name": "jQuery"},
+          {"icon": "devicon-html5-plain colored", "name": "HTML5"},
+          {"icon": "devicon-css3-plain colored", "name": "CSS3"},
+          {"icon": "devicon-bootstrap-plain colored", "name": "Bootstrap (Responsive Design)"},
           {"icon": "devicon-tailwindcss-original colored", "name": "Tailwind CSS"},
-          {"icon": "devicon-jinja-plain colored", "name": "Jinja2"}
+          {"icon": "devicon-dotnetcore-plain colored", "name": ".NET / ASP.NET Core"}
         ]
       },
       {
-        "title": "AI Technology",
+        "title": "Frontend Technologies",
         "items": [
+          {"icon": "devicon-javascript-plain colored", "name": "JavaScript"},
+          {"icon": "devicon-react-original colored", "name": "ReactJS"},
+          {"icon": "devicon-nextjs-plain", "name": "NextJS"},
+          {"icon": "devicon-tailwindcss-original colored", "name": "Tailwind CSS"},
+          {"icon": "devicon-bootstrap-plain colored", "name": "Bootstrap"},
+          {"icon": "devicon-jquery-plain colored", "name": "jQuery + DataTables"}
+        ]
+      },
+      {
+        "title": "Backend & Frameworks",
+        "items": [
+          {"icon": "devicon-django-plain colored", "name": "Django (Python)"},
+          {"icon": "devicon-laravel-plain colored", "name": "Laravel (PHP)"},
+          {"icon": "devicon-supabase-plain colored", "name": "Supabase"},
+          {"icon": "fas fa-network-wired", "name": "REST API Development"}
+        ]
+      },
+      {
+        "title": "Programming Languages",
+        "items": [
+          {"icon": "devicon-python-plain colored", "name": "Python"},
+          {"icon": "devicon-php-plain colored", "name": "PHP (Basic)"},
+          {"icon": "devicon-typescript-plain colored", "name": "TypeScript"},
+          {"icon": "devicon-javascript-plain colored", "name": "JavaScript"},
+          {"icon": "devicon-mysql-plain colored", "name": "SQL (MySQL, PostgreSQL)"},
+          {"icon": "devicon-mongodb-plain colored", "name": "NoSQL (MongoDB)"},
+          {"icon": "devicon-c-plain colored", "name": "C (Basic)"},
+          {"icon": "devicon-csharp-plain colored", "name": "C# (Basic; upskilling)"}
+        ]
+      },
+      {
+        "title": "AI & Machine Learning",
+        "items": [
+          {"icon": "fas fa-link", "name": "LangChain Integration"},
           {"icon": "devicon-google-plain colored", "name": "Google Teachable Machine"},
           {"icon": "devicon-tensorflow-original colored", "name": "TensorFlow"},
-          {"icon": "devicon-opencv-plain colored", "name": "OpenCV"},
-          {"icon": "devicon-python-plain colored", "name": "LangChain"},
-          {"icon": "devicon-pytorch-original colored", "name": "Deep Learning"},
-          {"icon": "devicon-numpy-original colored", "name": "VADER Sentiment Analysis"},
-          {"icon": "devicon-python-plain colored", "name": "Orange"}
-          ]
-        },
+          {"icon": "fas fa-terminal", "name": "Prompt Engineering"},
+          {"icon": "fas fa-brain", "name": "ML for Beginners"}
+        ]
+      },
       {
-        "title": "Frameworks",
+        "title": "Data Analytics & Visualization",
         "items": [
-          {"icon": "devicon-django-plain colored", "name": "Django"},
-          {"icon": "devicon-react-original colored", "name": "React"},
-          {"icon": "devicon-nextjs-plain", "name": "Next.js 15"},
-          {"icon": "devicon-nodejs-plain colored", "name": "Node.js"},
-          {"icon": "devicon-fastapi-plain colored", "name": "FastAPI"},
-          {"icon": "devicon-electron-original colored", "name": "Electron"},
-          {"icon": "devicon-sqlalchemy-plain colored", "name": "SQLAlchemy"},
-          {"icon": "devicon-angularjs-plain colored", "name": "AngularJS"},
-          {"icon": "devicon-alpinejs-original colored", "name": "Alpine.js"},
-          {"icon": "devicon-laravel-plain colored", "name": "Laravel"},
-          {"icon": "devicon-mapbox-original colored", "name": "Leaflet"}
-          ]
-        }
-      ]
-    },
+          {"icon": "fas fa-chart-line", "name": "Data Analysis"},
+          {"icon": "fas fa-chart-area", "name": "Chart.js"},
+          {"icon": "devicon-google-plain colored", "name": "Google Looker Studio"},
+          {"icon": "fas fa-chart-pie", "name": "Tableau"},
+          {"icon": "fas fa-graduation-cap", "name": "Visualize Your Data (SoloLearn)"},
+          {"icon": "devicon-python-plain colored", "name": "Scientific Computing with Python"}
+        ]
+      },
+      {
+        "title": "Database Systems",
+        "items": [
+          {"icon": "devicon-mysql-plain colored", "name": "MySQL"},
+          {"icon": "devicon-postgresql-plain colored", "name": "PostgreSQL"},
+          {"icon": "devicon-mongodb-plain colored", "name": "MongoDB"},
+          {"icon": "devicon-microsoftsqlserver-plain colored", "name": "SQL Server 2022"}
+        ]
+      },
+      {
+        "title": "Geospatial Technologies",
+        "items": [
+          {"icon": "devicon-mapbox-original colored", "name": "Leaflet Maps Integration"},
+          {"icon": "fas fa-globe", "name": "Geographic Information Systems (GIS)"}
+        ]
+      },
+      {
+        "title": "Software Design & Documentation",
+        "items": [
+          {"icon": "fas fa-project-diagram", "name": "UML Diagramming"},
+          {"icon": "fas fa-sitemap", "name": "Basic Data Flow Diagramming"}
+        ]
+      },
+      {
+        "title": "Tools & Platforms",
+        "items": [
+          {"icon": "devicon-git-plain colored", "name": "Git"},
+          {"icon": "devicon-github-plain colored", "name": "GitHub & GitHub Actions"},
+          {"icon": "devicon-vscode-plain colored", "name": "VS Code"},
+          {"icon": "devicon-googlecloud-plain colored", "name": "Google Cloud Platform"},
+          {"icon": "devicon-amazonwebservices-plain colored", "name": "AWS"},
+          {"icon": "devicon-railway-plain colored", "name": "Railway"},
+          {"icon": "fas fa-cloud-upload-alt", "name": "Render"},
+          {"icon": "devicon-docker-plain colored", "name": "Docker"}
+        ]
+      }
+    ]
+  },
   {
     "id": "DataAnalysis",
     "label": "Working with Data",
@@ -62,7 +125,7 @@
           {"icon": "fas fa-chart-line", "name": "Data Analysis Skill"},
           {"icon": "fas fa-chart-pie", "name": "Data Visualization"},
           {"icon": "fas fa-lightbulb", "name": "Data Storytelling"},
-            {"icon": "devicon-mysql-plain colored", "name": "SQL"}
+          {"icon": "devicon-mysql-plain colored", "name": "SQL"}
         ]
       },
       {
@@ -73,8 +136,8 @@
           {"icon": "fas fa-chart-bar", "name": "Jamovi"},
           {"icon": "fas fa-file-excel", "name": "Excel"},
           {"icon": "devicon-postgresql-plain colored", "name": "PGAdmin4"},
-            {"icon": "devicon-dbeaver-plain colored", "name": "DBeaver"},
-            {"icon": "devicon-google-plain colored", "name": "Google Looker Studio"},
+          {"icon": "devicon-dbeaver-plain colored", "name": "DBeaver"},
+          {"icon": "devicon-google-plain colored", "name": "Google Looker Studio"},
           {"icon": "fas fa-briefcase", "name": "Business Intelligence (BI)"}
         ]
       },
@@ -116,7 +179,7 @@
       {
         "title": "Tools used",
         "items": [
-            {"icon": "devicon-kalilinux-plain colored", "name": "Kali Linux"},
+          {"icon": "devicon-kalilinux-plain colored", "name": "Kali Linux"},
           {"icon": "fas fa-code", "name": "Binwalk"},
           {"icon": "fas fa-code", "name": "Hexedit"},
           {"icon": "fas fa-code", "name": "Autopsy"},
@@ -134,29 +197,29 @@
       {
         "title": "UI/UX",
         "items": [
-            {"icon": "devicon-figma-plain colored", "name": "Figma"},
-            {"icon": "devicon-canva-original colored", "name": "Canva"},
-            {"icon": "devicon-visualstudio-plain colored", "name": "Visio"}
-          ]
-        },
+          {"icon": "devicon-figma-plain colored", "name": "Figma"},
+          {"icon": "devicon-canva-original colored", "name": "Canva"},
+          {"icon": "devicon-visualstudio-plain colored", "name": "Visio"}
+        ]
+      },
       {
         "title": "React Component Libraries",
         "items": [
-            {"icon": "devicon-react-original colored", "name": "ShadCN"},
-            {"icon": "devicon-materialui-plain colored", "name": "Material UI"},
-            {"icon": "devicon-tailwindcss-original colored", "name": "HeroIcons"}
-          ]
-        },
-        {
-          "title": "Wireframing/Diagrams",
-          "items": [
-            {"icon": "devicon-figma-plain colored", "name": "UML Diagrams"},
-            {"icon": "devicon-figma-plain colored", "name": "Draw.io"},
-            {"icon": "devicon-sketch-plain colored", "name": "Sketch"}
-          ]
-        }
-      ]
-    },
+          {"icon": "devicon-react-original colored", "name": "ShadCN"},
+          {"icon": "devicon-materialui-plain colored", "name": "Material UI"},
+          {"icon": "devicon-tailwindcss-original colored", "name": "HeroIcons"}
+        ]
+      },
+      {
+        "title": "Wireframing/Diagrams",
+        "items": [
+          {"icon": "devicon-figma-plain colored", "name": "UML Diagrams"},
+          {"icon": "devicon-figma-plain colored", "name": "Draw.io"},
+          {"icon": "devicon-sketch-plain colored", "name": "Sketch"}
+        ]
+      }
+    ]
+  },
   {
     "id": "OtherSkill",
     "label": "Other Skills",
@@ -168,46 +231,46 @@
           {"icon": "devicon-docker-plain colored", "name": "Docker"},
           {"icon": "devicon-vitejs-plain colored", "name": "Vite"},
           {"icon": "devicon-googlecloud-plain colored", "name": "Google Cloud"},
-            {"icon": "fas fa-cloud-upload-alt", "name": "Render"},
-            {"icon": "devicon-vercel-plain colored", "name": "Vercel"}
-          ]
-        },
+          {"icon": "fas fa-cloud-upload-alt", "name": "Render"},
+          {"icon": "devicon-vercel-plain colored", "name": "Vercel"}
+        ]
+      },
       {
         "title": "Command Line & Process",
         "items": [
           {"icon": "devicon-linux-plain colored", "name": "Linux Commands"},
-            {"icon": "devicon-powershell-plain colored", "name": "PowerShell Commands"},
-            {"icon": "devicon-markdown-original colored", "name": "Markdown Language"},
-            {"icon": "devicon-notion-plain colored", "name": "Project Documentation"},
-            {"icon": "devicon-github-plain colored", "name": "Software Development Life Cycle (SDLC)"}
-          ]
-        },
-        {
-          "title": "Development",
-          "items": [
-            {"icon": "devicon-html5-plain colored", "name": "Front-End Development"},
-            {"icon": "devicon-nodejs-plain colored", "name": "Back-End Development"},
-            {"icon": "devicon-python-plain colored", "name": "Chatbot Development"},
-            {"icon": "devicon-mysql-plain colored", "name": "Database Administration"}
-          ]
-        },
-        {
-          "title": "AI & Prompting",
-          "items": [
-            {"icon": "devicon-python-plain colored", "name": "AI Prompting"},
-            {"icon": "devicon-python-plain colored", "name": "Prompt Engineering"},
-            {"icon": "devicon-pytorch-original colored", "name": "Generative AI"}
-          ]
-        },
-        {
-          "title": "Specialized",
-          "items": [
-            {"icon": "devicon-mapbox-original colored", "name": "Geographic Information System (GIS)"},
-            {"icon": "devicon-cplusplus-plain colored", "name": "x86-64 Assembly Language (studying)"}
-          ]
-        }
-      ]
-    },
+          {"icon": "devicon-powershell-plain colored", "name": "PowerShell Commands"},
+          {"icon": "devicon-markdown-original colored", "name": "Markdown Language"},
+          {"icon": "devicon-notion-plain colored", "name": "Project Documentation"},
+          {"icon": "devicon-github-plain colored", "name": "Software Development Life Cycle (SDLC)"}
+        ]
+      },
+      {
+        "title": "Development",
+        "items": [
+          {"icon": "devicon-html5-plain colored", "name": "Front-End Development"},
+          {"icon": "devicon-nodejs-plain colored", "name": "Back-End Development"},
+          {"icon": "devicon-python-plain colored", "name": "Chatbot Development"},
+          {"icon": "devicon-mysql-plain colored", "name": "Database Administration"}
+        ]
+      },
+      {
+        "title": "AI & Prompting",
+        "items": [
+          {"icon": "devicon-python-plain colored", "name": "AI Prompting"},
+          {"icon": "devicon-python-plain colored", "name": "Prompt Engineering"},
+          {"icon": "devicon-pytorch-original colored", "name": "Generative AI"}
+        ]
+      },
+      {
+        "title": "Specialized",
+        "items": [
+          {"icon": "devicon-mapbox-original colored", "name": "Geographic Information System (GIS)"},
+          {"icon": "devicon-cplusplus-plain colored", "name": "x86-64 Assembly Language (studying)"}
+        ]
+      }
+    ]
+  },
   {
     "id": "SoftSkills",
     "label": "Soft Skills",
@@ -219,7 +282,12 @@
           {"icon": "fas fa-chart-line", "name": "Analytical Skills"},
           {"icon": "fas fa-keyboard", "name": "Clerical Skills"},
           {"icon": "fas fa-sort-numeric-up", "name": "Numerical Analysis"},
-          {"icon": "fas fa-database", "name": "Database Administration"}
+          {"icon": "fas fa-database", "name": "Database Administration"},
+          {"icon": "fas fa-lightbulb", "name": "Critical Thinking"},
+          {"icon": "fas fa-puzzle-piece", "name": "Problem Solving"},
+          {"icon": "fas fa-users", "name": "Agile Collaboration"},
+          {"icon": "fas fa-file-alt", "name": "Documentation"},
+          {"icon": "fas fa-chalkboard-teacher", "name": "Presentation Skills"}
         ]
       }
     ]


### PR DESCRIPTION
## Summary
- restore legacy skill categories (Working with Data, CTF, UI/UX, Other Skills) alongside refreshed programming groups
- merge new soft skill entries with the original list

## Testing
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm test` *(fails: sh: 1: vitest: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68aac686f80c8329bb423e70d49d7ced