### PR TITLE
Ensure project cards fill grid row height

### DIFF
--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -121,10 +121,11 @@ export default function ProjectsPage() {
               initial={{ opacity: 0, y: 12 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ delay: i * 0.05, duration: 0.35 }}
+              className="h-full"
             >
               <Card
                 className={[
-                  "group relative min-h-[460px] overflow-hidden rounded-2xl p-4",
+                  "group relative min-h-[460px] h-full overflow-hidden rounded-2xl p-4",
                   "border border-teal-200/70 bg-white/85 backdrop-blur",
                   "dark:border-teal-800/70 dark:bg-gray-950/60",
                   "transition-shadow hover:shadow-lg hover:shadow-teal-300/30 dark:hover:shadow-teal-900/20",


### PR DESCRIPTION
## Summary
- Keep project cards at full height to align with the tallest item in each row

## Testing
- `npm run lint` *(fails: next: not found)*
- `npm test` *(fails: vitest: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68aac6c6c57c8329a08b632b4614328f