### PR TITLE
feat: wire up McDonald's project PDF

### DIFF
--- a/components/project-details/McdonaldsSentimentAnalysis.tsx
+++ b/components/project-details/McdonaldsSentimentAnalysis.tsx
@@ -2,16 +2,20 @@ import ProjectOverview from "./ProjectOverview";
 import ProjectSection from "./ProjectSection";
 import ProjectGallery from "./ProjectGallery";
 import { getProjectImages } from "@/lib/project-images";
+import { getProjectPdfs } from "@/lib/project-pdfs";
+import { withBasePath } from "@/lib/utils";
 
 export default async function McdonaldsSentimentAnalysis() {
   const images = await getProjectImages("mcdonalds-sentiment-analysis");
+  const pdfs = await getProjectPdfs("mcdonalds-sentiment-analysis");
+  const pdf = pdfs[0];
   return (
     <div className="space-y-12">
       <ProjectOverview
         title="McDonald's Sentiment Analysis"
         images={images.length ? images : ["/static/placeholders/django.png"]}
         alt="McDonald&apos;s Sentiment Analysis screenshot"
-        downloadUrl="/mcdonalds-sentiment-analysis/pdfs/McDonaldsSentimentAnalysis.pdf"
+        downloadUrl={pdf}
       >
         <p>
           <strong>Overview:</strong> Sentiment analysis of over 33,000
@@ -119,14 +123,16 @@ export default async function McdonaldsSentimentAnalysis() {
 
       <ProjectSection title="Links">
         <ul className="list-disc pl-6">
-          <li>
-            <a
-              href="/mcdonalds-sentiment-analysis/pdfs/McDonaldsSentimentAnalysis.pdf"
-              className="text-teal-600 hover:underline"
-            >
-              Project Documentation (PDF)
-            </a>
-          </li>
+          {pdf && (
+            <li>
+              <a
+                href={withBasePath(pdf)}
+                className="text-teal-600 hover:underline"
+              >
+                Project Documentation (PDF)
+              </a>
+            </li>
+          )}
         </ul>
       </ProjectSection>
 

--- a/lib/project-pdfs.ts
+++ b/lib/project-pdfs.ts
@@ -1,0 +1,16 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+export async function getProjectPdfs(slug: string): Promise<string[]> {
+  try {
+    const jsonPath = path.join(process.cwd(), 'public', slug, 'pdfs', 'pdfs.json');
+    const data = await fs.readFile(jsonPath, 'utf8');
+    const names = JSON.parse(data) as string[];
+    if (!Array.isArray(names) || names.length === 0) {
+      return [];
+    }
+    return names.map((name) => `/${slug}/pdfs/${name}`);
+  } catch {
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary
- add utility to load project PDFs from `public/<slug>/pdfs/pdfs.json`
- link McDonald's Sentiment Analysis page to its PDF via new helper

## Testing
- `npm run lint` *(fails: next: not found)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aada45700c8329b0f79f0a89320732