### PR TITLE
Add AI-powered Email Generator screenshots

### DIFF
--- a/public/ai-powered-email-generator/images/images.json
+++ b/public/ai-powered-email-generator/images/images.json
@@ -1,1 +1,7 @@
-[]
+[
+  "Dashboard.png",
+  "Compose Email.png",
+  "Email Logs.png",
+  "Audio Transcribe.png",
+  "Audio Transcribe Result.png"
+]

--- a/public/data/projects.json
+++ b/public/data/projects.json
@@ -301,7 +301,7 @@
   },
   {
     "title": "AI-Powered Email Generator",
-    "image": "/static/placeholders/ai.png",
+    "image": "/ai-powered-email-generator/images/Dashboard.png",
     "alt": "AI-Powered Email Generator Image",
     "description": "Django and LangChain assistant that crafts professional emails with adjustable tone and signature details, Gmail sending, audio transcription, and a lightweight CRM.",
     "collaborators": null,
@@ -321,7 +321,11 @@
     "details": "project-details/ai-powered-email-generator",
     "period": "Aug 2025 - Present",
     "images": [
-      "/static/placeholders/ai.png"
+      "/ai-powered-email-generator/images/Dashboard.png",
+      "/ai-powered-email-generator/images/Compose Email.png",
+      "/ai-powered-email-generator/images/Email Logs.png",
+      "/ai-powered-email-generator/images/Audio Transcribe.png",
+      "/ai-powered-email-generator/images/Audio Transcribe Result.png"
     ]
   },
   {


### PR DESCRIPTION
## Summary
- reference real screenshots for AI-powered Email Generator project
- list screenshots in project metadata so detail page can display gallery

## Testing
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jsdom)*
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aadef55b4883298fc642d86fa75438