### PR TITLE
Double Itinerary Planner screenshots

### DIFF
--- a/components/project-details/ItineraryPlanner.tsx
+++ b/components/project-details/ItineraryPlanner.tsx
@@ -5,11 +5,12 @@ import { getProjectImages } from "@/lib/project-images";
 
 export default async function ItineraryPlanner() {
   const images = await getProjectImages("itinerary-planner");
+  const doubledImages = images.flatMap((img) => [img, img]);
   return (
     <div className="space-y-12">
       <ProjectOverview
         title="Itinerary Planner"
-        images={images.length ? images : ["/static/placeholders/php.png"]}
+        images={doubledImages.length ? doubledImages : ["/static/placeholders/php.png"]}
         alt="Itinerary Planner screenshot"
         githubUrl="https://github.com/Seanneskie/itinerary-planner"
       >
@@ -148,9 +149,9 @@ php artisan serve`}</pre>
         </ul>
       </ProjectSection>
 
-      {images.length > 0 && (
+      {doubledImages.length > 0 && (
         <ProjectSection title="Screenshots">
-          <ProjectGallery images={images} alt="Itinerary Planner screenshot" />
+          <ProjectGallery images={doubledImages} alt="Itinerary Planner screenshot" />
         </ProjectSection>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Duplicate itinerary-planner screenshots so each image appears twice in overview and gallery.

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jsdom)*
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae69ea56cc8329bbb338c227c4ccd4