### PR TITLE
Add services section to homepage

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,7 @@
 import Profile, { MyStory } from "@/components/profile";
 import Banner from "@/components/banner";
+import WorkExperiences from "@/components/work-experiences";
+import ServicesSection from "@/components/services";
 import Link from "next/link";
 
 export default function HomePage() {
@@ -33,6 +35,8 @@ export default function HomePage() {
       <div className="container mx-auto max-w-7xl space-y-16 px-4 py-12">
         <Profile />
         <MyStory />
+        <WorkExperiences />
+        <ServicesSection />
         <div className="flex justify-center">
           <Link
             href="/profile"

--- a/components/services/ServicesSection.tsx
+++ b/components/services/ServicesSection.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useData } from "@/lib/use-data";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import * as Icons from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+interface Service {
+  title: string;
+  description: string;
+  icon: keyof typeof Icons;
+}
+
+export default function ServicesSection() {
+  const { data, loading, error } = useData<Service[]>("services.json");
+
+  if (loading)
+    return <p className="text-black dark:text-white">Loading services...</p>;
+  if (error || !data)
+    return (
+      <p className="text-red-600 dark:text-red-400">Failed to load services.</p>
+    );
+
+  return (
+    <section className="space-y-4" aria-labelledby="services-title">
+      <h1
+        id="services-title"
+        className="text-3xl font-bold tracking-tight text-teal-700 dark:text-teal-400"
+      >
+        Services
+      </h1>
+      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+        {data.map((svc) => {
+          const Icon = (Icons as Record<string, LucideIcon>)[svc.icon] ?? Icons.Code2;
+          return (
+            <Card
+              key={svc.title}
+              className="border-teal-600/10 bg-white/70 backdrop-blur-sm transition-shadow hover:shadow-md dark:border-teal-400/10 dark:bg-teal-900/20"
+            >
+              <CardHeader className="items-center text-center pb-2">
+                <Icon className="mb-2 h-10 w-10 text-teal-600 dark:text-teal-400" />
+                <CardTitle className="text-teal-800 dark:text-teal-200">
+                  {svc.title}
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-center text-sm text-gray-700 dark:text-gray-200">
+                  {svc.description}
+                </p>
+              </CardContent>
+            </Card>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+

--- a/components/services/index.ts
+++ b/components/services/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ServicesSection";

--- a/public/data/services.json
+++ b/public/data/services.json
@@ -1,0 +1,22 @@
+[
+  {
+    "title": "Full-Stack Development",
+    "description": "Building responsive web applications with Next.js, Django, and modern tooling.",
+    "icon": "Code2"
+  },
+  {
+    "title": "API & Backend Services",
+    "description": "Designing and integrating RESTful APIs and scalable backend systems.",
+    "icon": "Server"
+  },
+  {
+    "title": "Data Visualization",
+    "description": "Transforming data into insights through charts and interactive dashboards.",
+    "icon": "BarChart3"
+  },
+  {
+    "title": "UI/UX Design",
+    "description": "Crafting accessible interfaces focused on clarity and usability.",
+    "icon": "Palette"
+  }
+]


### PR DESCRIPTION
## Summary
- add `services.json` data file
- build `ServicesSection` to load and display services
- render services after work experience section on home page

## Testing
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4d21965b08329a9ae5f8df4114dca