### PR TITLE
feat: showcase work experiences with carousel

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 import Profile, { MyStory } from "@/components/profile";
 import Banner from "@/components/banner";
 import Link from "next/link";
+import { WorkExperienceCarousel } from "@/components/work-experiences";
 
 export default function HomePage() {
   return (
@@ -33,6 +34,7 @@ export default function HomePage() {
       <div className="container mx-auto max-w-7xl space-y-16 px-4 py-12">
         <Profile />
         <MyStory />
+        <WorkExperienceCarousel />
         <div className="flex justify-center">
           <Link
             href="/profile"

--- a/components/work-experiences/WorkExperienceCarousel.tsx
+++ b/components/work-experiences/WorkExperienceCarousel.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import Image from "next/image";
+import { withBasePath } from "@/lib/utils";
+import { useData } from "@/lib/use-data";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+} from "@/components/ui/carousel";
+
+interface WorkExperience {
+  company: string;
+  project: string;
+  period: string;
+  images: { src: string; alt: string }[];
+}
+
+export default function WorkExperienceCarousel() {
+  const { data, loading, error } = useData<WorkExperience[]>("work-experiences.json");
+
+  if (loading) {
+    return <p>Loading work experiences...</p>;
+  }
+
+  if (error || !data) {
+    return <p className="text-red-600 dark:text-red-400">Failed to load work experiences.</p>;
+  }
+
+  return (
+    <section className="space-y-6" aria-labelledby="work-carousel-title">
+      <h2
+        id="work-carousel-title"
+        className="text-3xl font-bold tracking-tight text-teal-700 dark:text-teal-400"
+      >
+        Work Experiences
+      </h2>
+      <div className="grid gap-6 md:grid-cols-2">
+        {data.map((exp) => (
+          <Card
+            key={`${exp.company}-${exp.project}-${exp.period}`}
+            className="overflow-hidden border-teal-600/10 bg-white/70 shadow-sm backdrop-blur-sm dark:border-teal-400/10 dark:bg-teal-900/20"
+          >
+            <CardHeader className="pb-2">
+              <CardTitle className="text-xl text-teal-800 dark:text-teal-200">
+                {exp.company}
+              </CardTitle>
+              <p className="text-sm text-gray-700 dark:text-gray-300">{exp.project}</p>
+              <p className="text-xs text-gray-500 dark:text-gray-400">{exp.period}</p>
+            </CardHeader>
+            <CardContent>
+              {exp.images.length > 0 && (
+                <Carousel className="w-full" opts={{ align: "start" }}>
+                  <CarouselContent>
+                    {exp.images.map((img) => (
+                      <CarouselItem key={img.src}>
+                        <div className="relative aspect-video w-full overflow-hidden rounded-md">
+                          <Image
+                            src={withBasePath(img.src)}
+                            alt={img.alt}
+                            fill
+                            className="object-cover"
+                            sizes="(max-width: 768px) 100vw, 50vw"
+                          />
+                        </div>
+                      </CarouselItem>
+                    ))}
+                  </CarouselContent>
+                  <CarouselPrevious className="left-2 top-1/2 -translate-y-1/2 shadow-sm" />
+                  <CarouselNext className="right-2 top-1/2 -translate-y-1/2 shadow-sm" />
+                </Carousel>
+              )}
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </section>
+  );
+}
+

--- a/components/work-experiences/index.ts
+++ b/components/work-experiences/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./WorkExperiences";
+export { default as WorkExperienceCarousel } from "./WorkExperienceCarousel";

--- a/public/data/work-experiences.json
+++ b/public/data/work-experiences.json
@@ -3,6 +3,10 @@
     "company": "TSP Marine Industries",
     "project": "Vessel Inventory Management System (VIMS)",
     "period": "November 2024 – June 2025",
+    "images": [
+      { "src": "/vims/images/1.png", "alt": "VIMS dashboard" },
+      { "src": "/vims/images/2.png", "alt": "VIMS inventory table" }
+    ],
     "tech": [
       "Next.js 15",
       "TypeScript",
@@ -25,6 +29,10 @@
     "company": "LGU Gensan – CEMCDO",
     "project": "Cooperative Profiling & Fund Utilization System",
     "period": "January 2025 – April 2025",
+    "images": [
+      { "src": "/cemcdo-app/images/Landing Page.png", "alt": "CEMCDO landing page" },
+      { "src": "/cemcdo-app/images/Admin Dashboard.png", "alt": "CEMCDO admin dashboard" }
+    ],
     "tech": [
       "Django",
       "Tailwind CSS",
@@ -46,6 +54,7 @@
     "company": "COTSEYE Project",
     "project": "Crowd Mapping for Crown of Thorns (COTS) Monitoring",
     "period": "May 2024 – August 2024",
+    "images": [],
     "tech": [
       "Django",
       "Python",


### PR DESCRIPTION
## Summary
- extend work experience data with image metadata
- add WorkExperienceCarousel component and export
- display work experience carousel on home page

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: vitest not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b4d213453c8329ac4d1d39b26cbd90