### PR TITLE
Add hover previews for certificate images

### DIFF
--- a/components/certificates/certificates-section.tsx
+++ b/components/certificates/certificates-section.tsx
@@ -13,6 +13,11 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
+import {
+  HoverCard,
+  HoverCardTrigger,
+  HoverCardContent,
+} from "@/components/ui/hover-card";
 import { useData } from "@/lib/use-data";
 import { withBasePath } from "@/lib/utils";
 
@@ -133,33 +138,41 @@ export default function CertificatesSection() {
                 labels.length > MAX_BADGES || c.desc.length > MAX_DESC_LENGTH;
               const badgeCls =
                 "rounded-full bg-teal-50 text-teal-800 ring-1 ring-inset ring-teal-200 dark:bg-teal-900/30 dark:text-teal-200 dark:ring-teal-800";
+              const imageSrc = c.link
+                ? c.link.startsWith("/")
+                  ? withBasePath(c.link)
+                  : c.link
+                : "";
+              const isImage = /\.(png|jpe?g|gif|webp)$/i.test(imageSrc);
 
-              return (
-                <motion.li
-                  key={c.title + i}
-                  role="listitem"
-                  className="h-full"
-                  layout
-                  initial={{ opacity: 0, y: 12 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  exit={{ opacity: 0, y: -12 }}
-                  transition={{ delay: i * 0.05, duration: 0.35 }}
-                >
-                  <Card
-                    className={[
-                      "group relative overflow-hidden rounded-2xl p-4",
-                      "border border-teal-200/70 bg-white/85 backdrop-blur",
-                      "dark:border-teal-800/70 dark:bg-gray-950/60",
-                      "transition-shadow hover:shadow-lg hover:shadow-teal-300/30 dark:hover:shadow-teal-900/20",
-                      "focus-within:ring-1 focus-within:ring-teal-500/60",
-                      "flex flex-col",
-                      isExpanded ? "" : "h-64",
-                    ].join(" ")}
+                return (
+                  <motion.li
+                    key={c.title + i}
+                    role="listitem"
+                    className="h-full"
+                    layout
+                    initial={{ opacity: 0, y: 12 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={{ opacity: 0, y: -12 }}
+                    transition={{ delay: i * 0.05, duration: 0.35 }}
                   >
-                    <div className="flex-1">
-                      <h3 className="text-lg font-semibold text-teal-800 dark:text-teal-200">
-                        {c.title}
-                      </h3>
+                    <HoverCard>
+                      <HoverCardTrigger asChild>
+                        <Card
+                          className={[
+                            "group relative overflow-hidden rounded-2xl p-4",
+                            "border border-teal-200/70 bg-white/85 backdrop-blur",
+                            "dark:border-teal-800/70 dark:bg-gray-950/60",
+                            "transition-shadow hover:shadow-lg hover:shadow-teal-300/30 dark:hover:shadow-teal-900/20",
+                            "focus-within:ring-1 focus-within:ring-teal-500/60",
+                            "flex flex-col",
+                            isExpanded ? "" : "h-64",
+                          ].join(" ")}
+                        >
+                        <div className="flex-1">
+                          <h3 className="text-lg font-semibold text-teal-800 dark:text-teal-200">
+                            {c.title}
+                          </h3>
 
                       <div className="mt-2 flex flex-wrap items-center gap-2">
                         {labels
@@ -188,26 +201,22 @@ export default function CertificatesSection() {
                     </div>
 
                     <div className="mt-4 flex flex-col gap-2">
-                      {c.link && (
-                        <Button
-                          asChild
-                          size="sm"
-                          className="border-0 bg-gradient-to-r from-teal-600 via-cyan-500 to-sky-500 text-white focus-visible:border-teal-500 focus-visible:ring-teal-500/50"
-                        >
-                          <a
-                            href={
-                              c.link.startsWith("/")
-                                ? withBasePath(c.link)
-                                : c.link
-                            }
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            aria-label={`View ${c.title} certificate`}
+                        {c.link && (
+                          <Button
+                            asChild
+                            size="sm"
+                            className="border-0 bg-gradient-to-r from-teal-600 via-cyan-500 to-sky-500 text-white focus-visible:border-teal-500 focus-visible:ring-teal-500/50"
                           >
-                            View certificate
-                          </a>
-                        </Button>
-                      )}
+                            <a
+                              href={imageSrc}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              aria-label={`View ${c.title} certificate`}
+                            >
+                              View certificate
+                            </a>
+                          </Button>
+                        )}
 
                       {showToggle && (
                         <Button
@@ -230,9 +239,20 @@ export default function CertificatesSection() {
                       aria-hidden
                       className="pointer-events-none absolute -right-10 -top-10 h-28 w-28 rounded-full bg-teal-400/20 blur-2xl transition-opacity duration-300 group-hover:opacity-100 dark:bg-teal-500/15"
                     />
-                  </Card>
-                </motion.li>
-              );
+                        </Card>
+                      </HoverCardTrigger>
+                      {isImage && (
+                        <HoverCardContent className="w-80 p-0">
+                          <img
+                            src={imageSrc}
+                            alt={`${c.title} certificate`}
+                            className="h-auto w-full rounded-md"
+                          />
+                        </HoverCardContent>
+                      )}
+                    </HoverCard>
+                  </motion.li>
+                );
             })}
           </AnimatePresence>
         </ul>


### PR DESCRIPTION
## Summary
- show certificate previews on hover using HoverCard

## Testing
- `npm install` (fails: 403 Forbidden fetching jsdom)
- `npm run lint` (fails: next not found)
- `npm test` (fails: vitest not found)

------
https://chatgpt.com/codex/tasks/task_e_68b52deda3a08329ad0625f39a309557