### PR TITLE
refactor: move certificate card hook

### DIFF
--- a/components/certificates/certificates-section.tsx
+++ b/components/certificates/certificates-section.tsx
@@ -35,7 +35,6 @@ const MAX_BADGES = 6;
 export default function CertificatesSection() {
   const [search, setSearch] = useState("");
   const [tag, setTag] = useState("");
-  const [expanded, setExpanded] = useState<Record<number, boolean>>({});
 
   const { data, loading, error } = useData<Certificate[]>("certificates.json");
   const certificates = useMemo(() => data ?? [], [data]);
@@ -131,120 +130,120 @@ export default function CertificatesSection() {
           className="grid auto-rows-fr grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3"
         >
           <AnimatePresence>
-            {filtered.map((c: Certificate, i: number) => {
-              const labels = Array.from(new Set([...c.tags, ...c.skills]));
-              const isExpanded = !!expanded[i];
-              const badgeCls =
-                "rounded-full bg-teal-50 text-teal-800 ring-1 ring-inset ring-teal-200 dark:bg-teal-900/30 dark:text-teal-200 dark:ring-teal-800";
-              const viewLink = c.link
-                ? c.link.startsWith("/")
-                  ? withBasePath(c.link)
-                  : c.link
-                : "";
-              const imageSrc = useOgImage(c.link);
-
-              return (
-                <motion.li
-                  key={c.title + i}
-                  role="listitem"
-                  className="h-full"
-                  layout
-                  initial={{ opacity: 0, y: 12 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  exit={{ opacity: 0, y: -12 }}
-                  transition={{ delay: i * 0.05, duration: 0.35 }}
-                >
-                  <HoverCard>
-                    <HoverCardTrigger asChild>
-                      <Card
-                        onMouseEnter={() =>
-                          setExpanded((prev) => ({ ...prev, [i]: true }))
-                        }
-                        onMouseLeave={() =>
-                          setExpanded((prev) => ({ ...prev, [i]: false }))
-                        }
-                        className={[
-                          "group relative overflow-hidden rounded-2xl p-4",
-                          "border border-teal-200/70 bg-white/85 backdrop-blur",
-                          "dark:border-teal-800/70 dark:bg-gray-950/60",
-                          "transition-shadow hover:shadow-lg hover:shadow-teal-300/30 dark:hover:shadow-teal-900/20",
-                          "focus-within:ring-1 focus-within:ring-teal-500/60",
-                          "flex flex-col",
-                          isExpanded ? "" : "h-64",
-                        ].join(" ")}
-                      >
-                        <div className="flex-1">
-                          <h3 className="text-lg font-semibold text-teal-800 dark:text-teal-200">
-                            {c.title}
-                          </h3>
-
-                          <div className="mt-2 flex flex-wrap items-center gap-2">
-                            {labels
-                              .slice(0, isExpanded ? labels.length : MAX_BADGES)
-                              .map((label) => (
-                                <Badge
-                                  key={label}
-                                  variant="secondary"
-                                  className={badgeCls}
-                                >
-                                  {label}
-                                </Badge>
-                              ))}
-                          </div>
-
-                          <p
-                            className={[
-                              "mt-2 text-sm text-gray-700 dark:text-gray-200",
-                              !isExpanded && "line-clamp-3",
-                            ]
-                              .filter(Boolean)
-                              .join(" ")}
-                          >
-                            {c.desc}
-                          </p>
-                        </div>
-
-                        <div className="mt-4 flex flex-col gap-2">
-                          {c.link && (
-                            <Button
-                              asChild
-                              size="sm"
-                              className="border-0 bg-gradient-to-r from-teal-600 via-cyan-500 to-sky-500 text-white focus-visible:border-teal-500 focus-visible:ring-teal-500/50"
-                            >
-                              <a
-                                href={viewLink}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                aria-label={`View ${c.title} certificate`}
-                              >
-                                View certificate
-                              </a>
-                            </Button>
-                          )}
-                        </div>
-
-                        <span
-                          aria-hidden
-                          className="pointer-events-none absolute -right-10 -top-10 h-28 w-28 rounded-full bg-teal-400/20 blur-2xl transition-opacity duration-300 group-hover:opacity-100 dark:bg-teal-500/15"
-                        />
-                      </Card>
-                    </HoverCardTrigger>
-                    {imageSrc && (
-                      <HoverCardContent side="top" className="w-80 p-0">
-                        <img
-                          src={imageSrc}
-                          alt={`${c.title} certificate`}
-                          className="h-auto w-full rounded-md"
-                        />
-                      </HoverCardContent>
-                    )}
-                  </HoverCard>
-                </motion.li>
-              );
-            })}
+            {filtered.map((c: Certificate, i: number) => (
+              <CertificateCard key={c.title + i} certificate={c} index={i} />
+            ))}
           </AnimatePresence>
         </ul>
       )}
     </div>
+  );
+}
+
+interface CertificateCardProps {
+  certificate: Certificate;
+  index: number;
+}
+
+function CertificateCard({ certificate: c, index }: CertificateCardProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const labels = Array.from(new Set([...c.tags, ...c.skills]));
+  const badgeCls =
+    "rounded-full bg-teal-50 text-teal-800 ring-1 ring-inset ring-teal-200 dark:bg-teal-900/30 dark:text-teal-200 dark:ring-teal-800";
+  const viewLink = c.link
+    ? c.link.startsWith("/")
+      ? withBasePath(c.link)
+      : c.link
+    : "";
+  const imageSrc = useOgImage(c.link);
+
+  return (
+    <motion.li
+      role="listitem"
+      className="h-full"
+      layout
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -12 }}
+      transition={{ delay: index * 0.05, duration: 0.35 }}
+    >
+      <HoverCard>
+        <HoverCardTrigger asChild>
+          <Card
+            onMouseEnter={() => setIsExpanded(true)}
+            onMouseLeave={() => setIsExpanded(false)}
+            className={[
+              "group relative overflow-hidden rounded-2xl p-4",
+              "border border-teal-200/70 bg-white/85 backdrop-blur",
+              "dark:border-teal-800/70 dark:bg-gray-950/60",
+              "transition-shadow hover:shadow-lg hover:shadow-teal-300/30 dark:hover:shadow-teal-900/20",
+              "focus-within:ring-1 focus-within:ring-teal-500/60",
+              "flex flex-col",
+              isExpanded ? "" : "h-64",
+            ].join(" ")}
+          >
+            <div className="flex-1">
+              <h3 className="text-lg font-semibold text-teal-800 dark:text-teal-200">
+                {c.title}
+              </h3>
+
+              <div className="mt-2 flex flex-wrap items-center gap-2">
+                {labels
+                  .slice(0, isExpanded ? labels.length : MAX_BADGES)
+                  .map((label) => (
+                    <Badge key={label} variant="secondary" className={badgeCls}>
+                      {label}
+                    </Badge>
+                  ))}
+              </div>
+
+              <p
+                className={[
+                  "mt-2 text-sm text-gray-700 dark:text-gray-200",
+                  !isExpanded && "line-clamp-3",
+                ]
+                  .filter(Boolean)
+                  .join(" ")}
+              >
+                {c.desc}
+              </p>
+            </div>
+
+            <div className="mt-4 flex flex-col gap-2">
+              {c.link && (
+                <Button
+                  asChild
+                  size="sm"
+                  className="border-0 bg-gradient-to-r from-teal-600 via-cyan-500 to-sky-500 text-white focus-visible:border-teal-500 focus-visible:ring-teal-500/50"
+                >
+                  <a
+                    href={viewLink}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label={`View ${c.title} certificate`}
+                  >
+                    View certificate
+                  </a>
+                </Button>
+              )}
+            </div>
+
+            <span
+              aria-hidden
+              className="pointer-events-none absolute -right-10 -top-10 h-28 w-28 rounded-full bg-teal-400/20 blur-2xl transition-opacity duration-300 group-hover:opacity-100 dark:bg-teal-500/15"
+            />
+          </Card>
+        </HoverCardTrigger>
+        {imageSrc && (
+          <HoverCardContent side="top" className="w-80 p-0">
+            <img
+              src={imageSrc}
+              alt={`${c.title} certificate`}
+              className="h-auto w-full rounded-md"
+            />
+          </HoverCardContent>
+        )}
+      </HoverCard>
+    </motion.li>
   );
 }


### PR DESCRIPTION
## Summary
- extract CertificateCard component to avoid calling hooks inside loops
- fetch OG images within each card to maintain stable hook order

## Testing
- ⚠️ `npm install` (failed: 403 Forbidden - GET https://registry.npmjs.org/jsdom)
- ⚠️ `npm test` (failed: vitest: not found)
- ⚠️ `npm run lint` (failed: next: not found)


------
https://chatgpt.com/codex/tasks/task_e_68b534275a0483299f51c8f78010be5d