### PR TITLE
Support local certificate image paths

### DIFF
--- a/components/certificates/certificates-section.tsx
+++ b/components/certificates/certificates-section.tsx
@@ -27,6 +27,7 @@ interface Certificate {
   title: string;
   desc: string;
   link?: string;
+  image?: string;
   skills: string[];
 }
 
@@ -151,11 +152,13 @@ function CertificateCard({ certificate: c, index }: CertificateCardProps) {
   const badgeCls =
     "rounded-full bg-teal-50 text-teal-800 ring-1 ring-inset ring-teal-200 dark:bg-teal-900/30 dark:text-teal-200 dark:ring-teal-800";
   const viewLink = c.link
-    ? c.link.startsWith("/")
-      ? withBasePath(c.link)
-      : c.link
+    ? /^https?:\/\//.test(c.link)
+      ? c.link
+      : withBasePath(c.link.startsWith("/") ? c.link : `/${c.link}`)
     : "";
-  const { image: imageSrc, loading: imageLoading } = useOgImage(c.link);
+  const { image: imageSrc, loading: imageLoading } = useOgImage(
+    c.image ?? c.link
+  );
 
   return (
     <motion.li

--- a/lib/use-og-image.ts
+++ b/lib/use-og-image.ts
@@ -11,7 +11,11 @@ export function useOgImage(url?: string) {
     if (!url) return;
 
     if (IMAGE_REGEX.test(url)) {
-      setImage(url.startsWith("/") ? withBasePath(url) : url);
+      const isAbsolute = /^https?:\/\//.test(url);
+      const normalized = isAbsolute
+        ? url
+        : withBasePath(url.startsWith("/") ? url : `/${url}`);
+      setImage(normalized);
       setLoading(false);
       return;
     }

--- a/public/data/certificates.json
+++ b/public/data/certificates.json
@@ -134,6 +134,7 @@
     "title": "Civil Service Professional Examination",
     "desc": "Successfully passed the Civil Service Professional Examination, demonstrating proficiency in core competencies required for professional roles in Philippine government service. Date: August 2024",
     "link": "/static/pdfs/csc.pdf",
+    "image": "/static/placeholders/cert-placeholder.jpeg",
     "skills": [
       "OtherSkill"
     ]


### PR DESCRIPTION
## Summary
- handle relative paths and base path prefixes when resolving certificate image links
- allow optional `image` field for certificates and add placeholder image for civil service exam entry

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b537e690148329908f8370e49e874b