### PR TITLE
feat: support static and og images for certificates

### DIFF
--- a/components/certificates/certificates-section.tsx
+++ b/components/certificates/certificates-section.tsx
@@ -27,6 +27,7 @@ interface Certificate {
   title: string;
   desc: string;
   link?: string;
+  image?: string;
   skills: string[];
 }
 
@@ -150,12 +151,11 @@ function CertificateCard({ certificate: c, index }: CertificateCardProps) {
   const labels = Array.from(new Set([...c.tags, ...c.skills]));
   const badgeCls =
     "rounded-full bg-teal-50 text-teal-800 ring-1 ring-inset ring-teal-200 dark:bg-teal-900/30 dark:text-teal-200 dark:ring-teal-800";
-  const viewLink = c.link
-    ? c.link.startsWith("/")
-      ? withBasePath(c.link)
-      : c.link
-    : "";
-  const { image: imageSrc, loading: imageLoading } = useOgImage(c.link);
+  const rawLink = c.link ?? c.image ?? "";
+  const viewLink = rawLink.startsWith("/") ? withBasePath(rawLink) : rawLink;
+  const { image: imageSrc, loading: imageLoading } = useOgImage(
+    c.image ?? c.link
+  );
 
   return (
     <motion.li
@@ -210,7 +210,7 @@ function CertificateCard({ certificate: c, index }: CertificateCardProps) {
             </div>
 
             <div className="mt-4 flex flex-col gap-2">
-              {c.link && (
+              {rawLink && (
                 <Button
                   asChild
                   size="sm"

--- a/public/data/certificates.json
+++ b/public/data/certificates.json
@@ -101,6 +101,7 @@
     "title": "Visualize Your Data",
     "desc": "This course covers essential tools and techniques for visualizing data to uncover insights and drive decision-making. Date: March 2025",
     "link": "/static/certificates/visualize_your_data.jpg",
+    "image": "/static/certificates/visualize_your_data.jpg",
     "skills": [
       "DataAnalysis"
     ]
@@ -112,6 +113,7 @@
     "title": "Coding for Data",
     "desc": "Coding is an important part of data analysis, and can be used in a variety of ways. Date: October 2024",
     "link": "/static/certificates/coding_for_data.jpg",
+    "image": "/static/certificates/coding_for_data.jpg",
     "skills": [
       "DataAnalysis"
     ]
@@ -123,6 +125,7 @@
     "title": "Intro to C",
     "desc": "C is a general-purpose programming language. It was created in the 1970s by Dennis Ritchie and remains very widely used and influential. Date: October 2024",
     "link": "/static/certificates/intro_to_c.jpg",
+    "image": "/static/certificates/intro_to_c.jpg",
     "skills": [
       "Programming"
     ]
@@ -146,6 +149,7 @@
     "title": "Gemini for end-to-end SDLC - Google Cloud",
     "desc": "I learned how to develop and build a web application, fix errors in the application, develop tests, and query data with the help of Gemini AI. Date: September 2024",
     "link": "/static/certificates/gemini.png",
+    "image": "/static/certificates/gemini.png",
     "skills": [
       "OtherSkill",
       "Programming"
@@ -159,6 +163,7 @@
     "title": "LFC108 Cybersecurity Essentials - Linux Foundations",
     "desc": "Cybersecurity Essentials include the fundamental and core skills to protect sensitive data and organizational security Date: September 2024",
     "link": "/static/certificates/linuxcyber.png",
+    "image": "/static/certificates/linuxcyber.png",
     "skills": [
       "CTF"
     ]
@@ -171,6 +176,7 @@
     "title": "Frontend for Beginners - Solo Learn",
     "desc": "Front-end web development is the development of the graphical user interface of a website through the use of HTML, CSS, and JavaScript so users can view and interact with that website. Date: September 2024",
     "link": "/static/certificates/frontend.png",
+    "image": "/static/certificates/frontend.png",
     "skills": [
       "Programming"
     ]
@@ -183,6 +189,7 @@
     "title": "Web Development - Solo Learn",
     "desc": "Web development is the work involved in developing a website for the Internet or an intranet. Date: August 2024",
     "link": "/static/certificates/web-dev.png",
+    "image": "/static/certificates/web-dev.png",
     "skills": [
       "Programming"
     ]
@@ -195,6 +202,7 @@
     "title": "Digital Transformation with Google Cloud",
     "desc": "This course provides an overview of the types of opportunities and challenges that companies often encounter in their digital transformation journey. Date: February 1, 2024",
     "link": "/static/certificates/googlecloud-1.png",
+    "image": "/static/certificates/googlecloud-1.png",
     "skills": [
       "OtherSkill"
     ]
@@ -207,6 +215,7 @@
     "title": "Python Core - Solo Learn",
     "desc": "Python is a high-level, general-purpose programming language. Its design philosophy emphasizes code readability with the use of significant indentation. Date: December 2023",
     "link": "/static/certificates/python-2.png",
+    "image": "/static/certificates/python-2.png",
     "skills": [
       "Programming"
     ]
@@ -218,6 +227,7 @@
     "title": "Foundations of Geographic Information System",
     "desc": "A Geographic Information System (GIS) is a computer system that analyzes and displays geographically referenced information. Date: October 2023",
     "link": "/static/placeholders/cert-placeholder.jpeg",
+    "image": "/static/placeholders/cert-placeholder.jpeg",
     "skills": [
       "OtherSkill"
     ]
@@ -229,6 +239,7 @@
     "title": "Intel OpenVINO Training",
     "desc": "OpenVINO is an open-source software toolkit for optimizing and deploying deep learning models. Date: September 2022",
     "link": "/static/placeholders/cert-placeholder.jpeg",
+    "image": "/static/placeholders/cert-placeholder.jpeg",
     "skills": [
       "Programming"
     ]
@@ -241,6 +252,7 @@
     "title": "Python for Beginners- Solo Learn",
     "desc": "Python is a high-level, general-purpose programming language. Its design philosophy emphasizes code readability with the use of significant indentation. Date: August 2022",
     "link": "/static/certificates/python-1.png",
+    "image": "/static/certificates/python-1.png",
     "skills": [
       "Programming"
     ]
@@ -297,6 +309,7 @@
     "title": "No more code chaos: Git Good and Stay Organized",
     "desc": "Campus DevCon 2023 Date: May 2023",
     "link": "/static/certificates/sem4.png",
+    "image": "/static/certificates/sem4.png",
     "skills": [
       "VersionControl"
     ]
@@ -309,6 +322,7 @@
     "title": "Revolutionizing the Future: Exploring the Power of AI Tools and their Impact",
     "desc": "Campus DevCon 2023 Date: May 2023",
     "link": "/static/certificates/sem1.png",
+    "image": "/static/certificates/sem1.png",
     "skills": [
       "AI"
     ]
@@ -321,6 +335,7 @@
     "title": "Introduction to Cybersecurity: Building Awareness in Today’s Digital World",
     "desc": "Campus DevCon 2023 Date: May 2023",
     "link": "/static/certificates/sem2.png",
+    "image": "/static/certificates/sem2.png",
     "skills": [
       "Cybersecurity"
     ]
@@ -333,6 +348,7 @@
     "title": "Your Path in Technopreneurship",
     "desc": "Campus DevCon 2023 Date: May 2023",
     "link": "/static/certificates/sem3.png",
+    "image": "/static/certificates/sem3.png",
     "skills": [
       "Entrepreneurship"
     ]
@@ -345,6 +361,7 @@
     "title": "DevSecOps for Starters",
     "desc": "Campus DevCon 2023 Date: May 2023",
     "link": "/static/certificates/sem5.png",
+    "image": "/static/certificates/sem5.png",
     "skills": [
       "DevSecOps"
     ]
@@ -357,6 +374,7 @@
     "title": "Careers in Cloud Computing",
     "desc": "Campus DevCon 2023 Date: May 2023",
     "link": "/static/certificates/sem7.png",
+    "image": "/static/certificates/sem7.png",
     "skills": [
       "CloudComputing"
     ]
@@ -369,6 +387,7 @@
     "title": "Your Path in Technopreneurship",
     "desc": "Campus DevCon 2023 Date: May 2023",
     "link": "/static/certificates/sem6.png",
+    "image": "/static/certificates/sem6.png",
     "skills": [
       "Entrepreneurship"
     ]


### PR DESCRIPTION
## Summary
- allow certificates to specify separate image URLs
- load open graph images or static assets based on provided URLs

## Testing
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5394be31083298aecfe19fbe35bbb