### PR TITLE
fix: allow og-image route on static export

### DIFF
--- a/app/api/og-image/route.ts
+++ b/app/api/og-image/route.ts
@@ -1,5 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 
+// Mark the route as static so it can be used with `output: export`.
+export const dynamic = "force-static";
+
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
   const target = searchParams.get("url");


### PR DESCRIPTION
## Summary
- mark `app/api/og-image` route as static so build with `output: export` succeeds

## Testing
- `npm run lint` *(fails: next: not found)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b53f73bd0483299444976e4b757581