### PR TITLE
Add OJT photos to home carousel

### DIFF
--- a/public/data/photo-carousel.json
+++ b/public/data/photo-carousel.json
@@ -1,2 +1,14 @@
 [
+  { "src": "/photo-carousel/DFPS_poster.png", "label": "Project poster" },
+  { "src": "/photo-carousel/capstone_pic.jpg", "label": "Capstone project photo 1" },
+  { "src": "/photo-carousel/capstone_pic_2.jpg", "label": "Capstone project photo 2" },
+  { "src": "/photo-carousel/grad_1.jpg", "label": "Graduation photo 1" },
+  { "src": "/photo-carousel/grad_2.jpg", "label": "Graduation photo 2" },
+  { "src": "/photo-carousel/ojt.jpg", "label": "On-the-job training photo 1" },
+  { "src": "/photo-carousel/ojt_2.jpg", "label": "On-the-job training photo 2" },
+  { "src": "/photo-carousel/ojt_3.jpg", "label": "On-the-job training photo 3" },
+  { "src": "/photo-carousel/ojt_4.jpg", "label": "On-the-job training photo 4" },
+  { "src": "/photo-carousel/ojt_5.jpg", "label": "On-the-job training photo 5" },
+  { "src": "/photo-carousel/ojt_6.jpg", "label": "On-the-job training photo 6" },
+  { "src": "/photo-carousel/ojt_7.jpg", "label": "On-the-job training photo 7" }
 ]


### PR DESCRIPTION
## Summary
- populate photo carousel data with OJT and project images

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5440006448329b6a15de38b9b25f0