### PR TITLE
Improve photo carousel and work experience visuals

### DIFF
--- a/components/photo-carousel.tsx
+++ b/components/photo-carousel.tsx
@@ -47,7 +47,9 @@ export default function PhotoCarousel() {
                   />
                 </AspectRatio>
                 {photo.label && (
-                  <p className="text-center text-sm text-muted-foreground">{photo.label}</p>
+                  <p className="text-center text-sm text-teal-700 dark:text-teal-300">
+                    {photo.label}
+                  </p>
                 )}
               </div>
             </CarouselItem>

--- a/components/work-experiences/WorkExperienceCarousel.tsx
+++ b/components/work-experiences/WorkExperienceCarousel.tsx
@@ -17,6 +17,7 @@ interface WorkExperience {
   project: string;
   period: string;
   images: { src: string; alt: string }[];
+  summary: string;
 }
 
 export default function WorkExperienceCarousel() {
@@ -38,6 +39,9 @@ export default function WorkExperienceCarousel() {
       >
         Work Experiences
       </h2>
+      <p className="text-gray-700 dark:text-gray-300">
+        Snapshots from my on-the-job training and key projects.
+      </p>
       <div className="grid gap-6 md:grid-cols-2">
         {data.map((exp) => (
           <Card
@@ -51,7 +55,7 @@ export default function WorkExperienceCarousel() {
               <p className="text-sm text-gray-700 dark:text-gray-300">{exp.project}</p>
               <p className="text-xs text-gray-500 dark:text-gray-400">{exp.period}</p>
             </CardHeader>
-            <CardContent>
+            <CardContent className="space-y-4">
               {exp.images.length > 0 && (
                 <Carousel className="w-full" opts={{ align: "start" }}>
                   <CarouselContent>
@@ -73,6 +77,7 @@ export default function WorkExperienceCarousel() {
                   <CarouselNext className="right-2 top-1/2 -translate-y-1/2 shadow-sm" />
                 </Carousel>
               )}
+              <p className="text-gray-700 dark:text-gray-300">{exp.summary}</p>
             </CardContent>
           </Card>
         ))}

--- a/public/data/work-experiences.json
+++ b/public/data/work-experiences.json
@@ -4,6 +4,7 @@
     "project": "Vessel Inventory Management System (VIMS)",
     "period": "November 2024 – June 2025",
     "images": [
+      { "src": "/photo-carousel/ojt.jpg", "alt": "On-the-job training photo" },
       { "src": "/vims/images/1.png", "alt": "VIMS dashboard" },
       { "src": "/vims/images/2.png", "alt": "VIMS inventory table" }
     ],


### PR DESCRIPTION
## Summary
- restyle photo carousel labels using teal theme colors
- add descriptive text and summaries to work experience carousel
- include OJT photo in work experience data

## Testing
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b54e0c82288329a7f01327cc35b003