### PR TITLE
Rename photo carousel to highlights

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@ import Banner from "@/components/banner";
 import WorkExperiences from "@/components/work-experiences";
 import ServicesSection from "@/components/services";
 import Link from "next/link";
-import PhotoCarousel from "@/components/photo-carousel";
+import Highlights from "@/components/highlights";
 import { WorkExperienceCarousel } from "@/components/work-experiences";
 
 export default function HomePage() {
@@ -37,7 +37,7 @@ export default function HomePage() {
       <div className="container mx-auto max-w-7xl space-y-16 px-4 py-12">
         <Profile />
         <MyStory />
-        <PhotoCarousel />
+        <Highlights />
         <WorkExperienceCarousel />
         <ServicesSection />
         <div className="flex justify-center">

--- a/components/highlights.tsx
+++ b/components/highlights.tsx
@@ -6,49 +6,44 @@ import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious
 import { AspectRatio } from "@/components/ui/aspect-ratio";
 import { withBasePath } from "@/lib/utils";
 
-interface PhotoItem {
+interface HighlightItem {
   src: string;
   label: string;
 }
 
-export default function PhotoCarousel() {
-  const [photos, setPhotos] = React.useState<PhotoItem[]>([]);
+export default function Highlights() {
+  const [highlights, setHighlights] = React.useState<HighlightItem[]>([]);
 
   React.useEffect(() => {
-    fetch(withBasePath("/data/photo-carousel.json"))
+    fetch(withBasePath("/data/highlights.json"))
       .then((res) => res.json())
-      .then((data) => setPhotos(data))
-      .catch(() => setPhotos([]));
+      .then((data) => setHighlights(data))
+      .catch(() => setHighlights([]));
   }, []);
 
-  if (photos.length === 0) {
+  if (highlights.length === 0) {
     return (
-      <section id="photos" className="space-y-4">
-        <h2 className="text-2xl font-bold">Photo Carousel</h2>
+      <section id="highlights" className="space-y-4">
+        <h2 className="text-2xl font-bold">Highlights</h2>
         <p className="text-muted-foreground">No photos available.</p>
       </section>
     );
   }
 
   return (
-    <section id="photos" className="space-y-4">
-      <h2 className="text-2xl font-bold">Photo Carousel</h2>
+    <section id="highlights" className="space-y-4">
+      <h2 className="text-2xl font-bold">Highlights</h2>
       <Carousel className="w-full">
         <CarouselContent>
-          {photos.map((photo) => (
-            <CarouselItem key={photo.src} className="basis-full">
+          {highlights.map((highlight) => (
+            <CarouselItem key={highlight.src} className="basis-full">
               <div className="space-y-2">
                 <AspectRatio ratio={16 / 9} className="overflow-hidden rounded-xl bg-muted">
-                  <Image
-                    src={withBasePath(photo.src)}
-                    alt={photo.label}
-                    fill
-                    className="object-cover"
-                  />
+                  <Image src={withBasePath(highlight.src)} alt={highlight.label} fill className="object-cover" />
                 </AspectRatio>
-                {photo.label && (
+                {highlight.label && (
                   <p className="text-center text-sm text-teal-700 dark:text-teal-300">
-                    {photo.label}
+                    {highlight.label}
                   </p>
                 )}
               </div>

--- a/public/data/highlights.json
+++ b/public/data/highlights.json
@@ -10,5 +10,8 @@
   { "src": "/photo-carousel/ojt_4.jpg", "label": "On-the-job training photo 4" },
   { "src": "/photo-carousel/ojt_5.jpg", "label": "On-the-job training photo 5" },
   { "src": "/photo-carousel/ojt_6.jpg", "label": "On-the-job training photo 6" },
-  { "src": "/photo-carousel/ojt_7.jpg", "label": "On-the-job training photo 7" }
+  { "src": "/photo-carousel/ojt_7.jpg", "label": "On-the-job training photo 7" },
+  { "src": "/photo-carousel/decode2024_uctf_1.jpg", "label": "DECODE 2024 UCTF" },
+  { "src": "/photo-carousel/hack4gov3_regionals.jpg", "label": "Hack4Gov 3 Regionals" },
+  { "src": "/photo-carousel/hack4gov3_nationals.jpg", "label": "Hack4Gov 3 Nationals" }
 ]


### PR DESCRIPTION
## Summary
- rename photo carousel component and data file to highlights
- display highlights on the home page
- map additional images for the highlights section

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5511d45108329a63f47e1178d5b94