### PR TITLE
Fix icon typing and replace img with Next Image

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,5 @@
 import Profile, { MyStory } from "@/components/profile";
 import Banner from "@/components/banner";
-import WorkExperiences from "@/components/work-experiences";
 import ServicesSection from "@/components/services";
 import Link from "next/link";
 import Highlights from "@/components/highlights";

--- a/components/certificates/certificates-section.tsx
+++ b/components/certificates/certificates-section.tsx
@@ -21,6 +21,7 @@ import {
 import { useData } from "@/lib/use-data";
 import { withBasePath } from "@/lib/utils";
 import { useOgImage } from "@/lib/use-og-image";
+import Image from "next/image";
 
 interface Certificate {
   tags: string[];
@@ -237,9 +238,11 @@ function CertificateCard({ certificate: c, index }: CertificateCardProps) {
         {(imageLoading || imageSrc) && (
           <HoverCardContent side="top" className="w-80 p-0">
             {imageSrc ? (
-              <img
+              <Image
                 src={imageSrc}
                 alt={`${c.title} certificate`}
+                width={320}
+                height={200}
                 className="h-auto w-full rounded-md"
               />
             ) : (

--- a/components/services/ServicesSection.tsx
+++ b/components/services/ServicesSection.tsx
@@ -31,7 +31,7 @@ export default function ServicesSection() {
       </h1>
       <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
         {data.map((svc) => {
-          const Icon = (Icons as Record<string, LucideIcon>)[svc.icon] ?? Icons.Code2;
+          const Icon = (Icons[svc.icon as keyof typeof Icons] ?? Icons.Code2) as LucideIcon;
           return (
             <Card
               key={svc.title}


### PR DESCRIPTION
## Summary
- fix lucide icon typing in ServicesSection
- remove unused WorkExperiences import from HomePage
- replace certificate hover images with Next.js Image for optimization

## Testing
- `npm run lint` *(fails: next: not found)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b59d316ef88329a5ac1dfff6cfcd80