### PR TITLE
Avoid request.url in og-image API route

### DIFF
--- a/app/api/og-image/route.ts
+++ b/app/api/og-image/route.ts
@@ -4,8 +4,7 @@ import { NextRequest, NextResponse } from "next/server";
 export const dynamic = "force-static";
 
 export async function GET(req: NextRequest) {
-  const { searchParams } = new URL(req.url);
-  const target = searchParams.get("url");
+  const target = req.nextUrl.searchParams.get("url");
   if (!target) {
     return NextResponse.json({ image: null }, { status: 400 });
   }


### PR DESCRIPTION
## Summary
- use `req.nextUrl` to read query params for the `og-image` API route

## Testing
- `npm run lint`
- `npm test` *(fails: Failed to resolve import "@/components/awards" from "app/awards/page.tsx")*

------
https://chatgpt.com/codex/tasks/task_e_68b5acbf5f348329a37c903817d056f0