### PR TITLE
feat: log project image loading errors

### DIFF
--- a/lib/project-images.ts
+++ b/lib/project-images.ts
@@ -10,7 +10,8 @@ export async function getProjectImages(slug: string): Promise<string[]> {
       return [];
     }
     return names.map((name) => `/${slug}/images/${name}`);
-  } catch {
-    return [];
+  } catch (error) {
+    console.error(`Failed to load project images for slug "${slug}":`, error);
+    throw new Error(`Failed to load project images for slug "${slug}"`);
   }
 }


### PR DESCRIPTION
## Summary
- log detailed error when project image loading fails, including slug
- rethrow with informative message to aid debugging

## Testing
- `npm run lint`
- `npm test` *(fails: Error: Failed to resolve import "@/components/awards" from "app/awards/page.tsx". Does the file exist?)*

------
https://chatgpt.com/codex/tasks/task_e_68b9249b29f883298ff20f30c73c12f0