### PR TITLE
Refactor project gallery to use image objects

### DIFF
--- a/components/project-details/AICoinDetector.tsx
+++ b/components/project-details/AICoinDetector.tsx
@@ -4,13 +4,20 @@ import ProjectGallery from "./ProjectGallery";
 import { getProjectImages } from "@/lib/project-images";
 
 export default async function AICoinDetector() {
-  const images = await getProjectImages("ai-coin-detector");
+  const alt = "AI Coin Detector Screenshot";
+  const images = (await getProjectImages("ai-coin-detector")).map((src) => ({
+    src,
+    alt,
+  }));
   return (
     <div className="space-y-12">
       <ProjectOverview
         title="AI Coin Detector"
-        images={images.length ? images : ["/static/placeholders/ai.png"]}
-        alt="AI Coin Detector Screenshot"
+        images={
+          images.length
+            ? images
+            : [{ src: "/static/placeholders/ai.png", alt }]
+        }
         githubUrl="https://github.com/Seanneskie/AI-coin-detector-django"
         downloadUrl="/ai-coin-detector/pdfs/Philippine%20Peso%20Coin%20Detector%20and%20Counter.pdf"
       >
@@ -264,7 +271,7 @@ export default async function AICoinDetector() {
 
       {images.length > 0 && (
         <ProjectSection title="Screenshots">
-          <ProjectGallery images={images} alt="AI Coin Detector Screenshot" />
+          <ProjectGallery images={images} />
         </ProjectSection>
       )}
     </div>

--- a/components/project-details/AiPoweredEmailGenerator.tsx
+++ b/components/project-details/AiPoweredEmailGenerator.tsx
@@ -4,13 +4,19 @@ import ProjectGallery from "./ProjectGallery";
 import { getProjectImages } from "@/lib/project-images";
 
 export default async function AiPoweredEmailGenerator() {
-  const images = await getProjectImages("ai-powered-email-generator");
+  const alt = "AI Powered Email Generator screenshot";
+  const images = (await getProjectImages("ai-powered-email-generator")).map(
+    (src) => ({ src, alt })
+  );
   return (
     <div className="space-y-12">
       <ProjectOverview
         title="AI-Powered Email Generator"
-        images={images.length ? images : ["/static/placeholders/ai.png"]}
-        alt="AI Powered Email Generator screenshot"
+        images={
+          images.length
+            ? images
+            : [{ src: "/static/placeholders/ai.png", alt }]
+        }
         githubUrl="https://github.com/Seanneskie/email-generator"
       >
         <p>
@@ -69,7 +75,7 @@ export default async function AiPoweredEmailGenerator() {
 
       {images.length > 0 && (
         <ProjectSection title="Screenshots">
-          <ProjectGallery images={images} alt="AI Powered Email Generator screenshot" />
+          <ProjectGallery images={images} />
         </ProjectSection>
       )}
     </div>

--- a/components/project-details/AlbanyAirbnbDashboard.tsx
+++ b/components/project-details/AlbanyAirbnbDashboard.tsx
@@ -4,13 +4,22 @@ import ProjectGallery from "./ProjectGallery";
 import { getProjectImages } from "@/lib/project-images";
 
 export default async function AlbanyAirbnbDashboard() {
-  const images = await getProjectImages("albany-airbnb-dashboard");
+  const alt = "Albany Airbnb Dashboard screenshot";
+  const images = (await getProjectImages("albany-airbnb-dashboard")).map(
+    (src) => ({ src, alt })
+  );
   return (
     <div className="space-y-12">
       <ProjectOverview
         title="Albany Airbnb Dashboard"
-        images={images.length ? images : ["/static/placeholders/data-analytics.webp"]}
-        alt="Albany Airbnb Dashboard screenshot"
+        images={
+          images.length
+            ? images
+            : [{
+                src: "/static/placeholders/data-analytics.webp",
+                alt,
+              }]
+        }
       >
         <p>
           <strong>Overview:</strong> An interactive Streamlit dashboard that
@@ -44,7 +53,7 @@ export default async function AlbanyAirbnbDashboard() {
 
       {images.length > 0 && (
         <ProjectSection title="Screenshots">
-          <ProjectGallery images={images} alt="Albany Airbnb Dashboard screenshot" />
+          <ProjectGallery images={images} />
         </ProjectSection>
       )}
     </div>

--- a/components/project-details/BitcoinAnalysisApp.tsx
+++ b/components/project-details/BitcoinAnalysisApp.tsx
@@ -4,15 +4,23 @@ import ProjectGallery from "./ProjectGallery";
 import { getProjectImages } from "@/lib/project-images";
 
 export default async function BitcoinAnalysisApp() {
-  const images = await getProjectImages("bitcoin-analysis-app");
+  const alt = "Bitcoin Analysis App screenshot";
+  const images = (await getProjectImages("bitcoin-analysis-app")).map((src) => ({
+    src,
+    alt,
+  }));
   return (
     <div className="space-y-12">
       <ProjectOverview
         title="Bitcoin Analysis App"
         images={
-          images.length ? images : ["/static/placeholders/data-analytics.webp"]
+          images.length
+            ? images
+            : [{
+                src: "/static/placeholders/data-analytics.webp",
+                alt,
+              }]
         }
-        alt="Bitcoin Analysis App screenshot"
       >
         <p>
           <strong>Overview:</strong> The Bitcoin Analysis App explores
@@ -179,10 +187,7 @@ export default async function BitcoinAnalysisApp() {
 
       {images.length > 0 && (
         <ProjectSection title="Screenshots">
-          <ProjectGallery
-            images={images}
-            alt="Bitcoin Analysis App screenshot"
-          />
+          <ProjectGallery images={images} />
         </ProjectSection>
       )}
     </div>

--- a/components/project-details/BudgetSystem.tsx
+++ b/components/project-details/BudgetSystem.tsx
@@ -4,14 +4,21 @@ import ProjectGallery from "./ProjectGallery";
 import { getProjectImages } from "@/lib/project-images";
 
 export default async function BudgetSystem() {
-  const images = await getProjectImages("budget-system");
+  const alt = "Budget System screenshot";
+  const images = (await getProjectImages("budget-system")).map((src) => ({
+    src,
+    alt,
+  }));
   return (
     <div className="space-y-12">
       <ProjectOverview
         title="Budget System"
-        images={images.length ? images : ["/static/placeholders/next.png"]}
-        alt="Budget System screenshot"
-      >
+        images={
+          images.length
+            ? images
+            : [{ src: "/static/placeholders/next.png", alt }]
+        }
+        >
         <p>
           <strong>Overview:</strong> Layered ASP.NET Core and SQL Server
           application for managing personal budgets. Accounts track starting
@@ -48,7 +55,7 @@ export default async function BudgetSystem() {
 
       {images.length > 0 && (
         <ProjectSection title="Screenshots">
-          <ProjectGallery images={images} alt="Budget System screenshot" />
+          <ProjectGallery images={images} />
         </ProjectSection>
       )}
     </div>

--- a/components/project-details/CemcdoApp.tsx
+++ b/components/project-details/CemcdoApp.tsx
@@ -4,13 +4,20 @@ import ProjectGallery from "./ProjectGallery";
 import { getProjectImages } from "@/lib/project-images";
 
 export default async function CemcdoApp() {
-  const images = await getProjectImages("cemcdo-app");
+  const alt = "CEMCDO App screenshot";
+  const images = (await getProjectImages("cemcdo-app")).map((src) => ({
+    src,
+    alt,
+  }));
   return (
     <div className="space-y-12">
       <ProjectOverview
         title="CEMCDO App"
-        images={images.length ? images : ["/static/placeholders/django.png"]}
-        alt="CEMCDO App screenshot"
+        images={
+          images.length
+            ? images
+            : [{ src: "/static/placeholders/django.png", alt }]
+        }
         githubUrl="https://cemcdo-demo.onrender.com/"
         linkLabel="View Site"
       >
@@ -193,7 +200,7 @@ export default async function CemcdoApp() {
 
       {images.length > 0 && (
         <ProjectSection title="Screenshots">
-          <ProjectGallery images={images} alt="CEMCDO App screenshot" />
+          <ProjectGallery images={images} />
         </ProjectSection>
       )}
     </div>

--- a/components/project-details/CnsmWebsite.tsx
+++ b/components/project-details/CnsmWebsite.tsx
@@ -4,13 +4,20 @@ import ProjectGallery from "./ProjectGallery";
 import { getProjectImages } from "@/lib/project-images";
 
 export default async function CnsmWebsite() {
-  const images = await getProjectImages("cnsm-website");
+  const alt = "CNSM website screenshot";
+  const images = (await getProjectImages("cnsm-website")).map((src) => ({
+    src,
+    alt,
+  }));
   return (
     <div className="space-y-12">
       <ProjectOverview
         title="CNSM Website"
-        images={images.length ? images : ["/static/placeholders/Mern.png"]}
-        alt="CNSM website screenshot"
+        images={
+          images.length
+            ? images
+            : [{ src: "/static/placeholders/Mern.png", alt }]
+        }
         githubUrl="https://github.com/Seanneskie/advDB-CNSM-Website"
       >
         <p>
@@ -227,7 +234,7 @@ export default async function CnsmWebsite() {
 
       {images.length > 0 && (
         <ProjectSection title="Screenshots">
-          <ProjectGallery images={images} alt="CNSM website screenshot" />
+          <ProjectGallery images={images} />
         </ProjectSection>
       )}
     </div>

--- a/components/project-details/DesktopPayrollManagementSystem.tsx
+++ b/components/project-details/DesktopPayrollManagementSystem.tsx
@@ -4,15 +4,19 @@ import ProjectGallery from "./ProjectGallery";
 import { getProjectImages } from "@/lib/project-images";
 
 export default async function DesktopPayrollManagementSystem() {
-  const images = await getProjectImages(
-    "desktop-payroll-management-system"
-  );
+  const alt = "Desktop Payroll Management System screenshot";
+  const images = (
+    await getProjectImages("desktop-payroll-management-system")
+  ).map((src) => ({ src, alt }));
   return (
     <div className="space-y-12">
       <ProjectOverview
         title="Desktop Payroll Management System"
-        images={images.length ? images : ["/static/placeholders/next.png"]}
-        alt="Desktop Payroll Management System screenshot"
+        images={
+          images.length
+            ? images
+            : [{ src: "/static/placeholders/next.png", alt }]
+        }
       >
         <p>
           <strong>Overview:</strong> Cross-platform payroll management
@@ -89,7 +93,7 @@ export default async function DesktopPayrollManagementSystem() {
 
       {images.length > 0 && (
         <ProjectSection title="Screenshots">
-          <ProjectGallery images={images} alt="Desktop Payroll Management System screenshot" />
+          <ProjectGallery images={images} />
         </ProjectSection>
       )}
     </div>

--- a/components/project-details/DigitalFreelancerProfilingApp.tsx
+++ b/components/project-details/DigitalFreelancerProfilingApp.tsx
@@ -4,13 +4,19 @@ import ProjectGallery from "./ProjectGallery";
 import { getProjectImages } from "@/lib/project-images";
 
 export default async function DigitalFreelancerProfilingApp() {
-  const images = await getProjectImages("digital-freelancer-profiling-app");
+  const alt = "Digital Freelancer Profiling App screenshot";
+  const images = (
+    await getProjectImages("digital-freelancer-profiling-app")
+  ).map((src) => ({ src, alt }));
   return (
     <div className="space-y-12">
       <ProjectOverview
         title="Digital Freelancer Profiling App"
-        images={images.length ? images : ["/static/placeholders/next.png"]}
-        alt="Digital Freelancer Profiling App screenshot"
+        images={
+          images.length
+            ? images
+            : [{ src: "/static/placeholders/next.png", alt }]
+        }
         downloadUrl="/digital-freelancer-profiling-app/pdfs/DPFS_UserManual.pdf"
       >
         <p>
@@ -109,7 +115,7 @@ export default async function DigitalFreelancerProfilingApp() {
 
       {images.length > 0 && (
         <ProjectSection title="Screenshots">
-          <ProjectGallery images={images} alt="Digital Freelancer Profiling App screenshot" />
+          <ProjectGallery images={images} />
         </ProjectSection>
       )}
     </div>

--- a/components/project-details/ExampleProject.tsx
+++ b/components/project-details/ExampleProject.tsx
@@ -4,13 +4,20 @@ import ProjectGallery from "./ProjectGallery";
 import { getProjectImages } from "@/lib/project-images";
 
 export default async function ExampleProject() {
-  const images = await getProjectImages("example-project");
+  const alt = "Example project screenshot";
+  const images = (await getProjectImages("example-project")).map((src) => ({
+    src,
+    alt,
+  }));
   return (
     <div className="space-y-12">
       <ProjectOverview
         title="Example Project"
-        images={images.length ? images : ["/static/placeholders/ai.png"]}
-        alt="Example project screenshot"
+        images={
+          images.length
+            ? images
+            : [{ src: "/static/placeholders/ai.png", alt }]
+        }
       >
         <p>
           <strong>Overview:</strong> Replace this text with a short summary of
@@ -45,7 +52,7 @@ export default async function ExampleProject() {
 
       {images.length > 0 && (
         <ProjectSection title="Screenshots">
-          <ProjectGallery images={images} alt="Example project screenshot" />
+          <ProjectGallery images={images} />
         </ProjectSection>
       )}
     </div>

--- a/components/project-details/HeadlessEcommerceMiniStore.tsx
+++ b/components/project-details/HeadlessEcommerceMiniStore.tsx
@@ -4,15 +4,17 @@ import ProjectGallery from "./ProjectGallery";
 import { getProjectImages } from "@/lib/project-images";
 
 export default async function HeadlessEcommerceMiniStore() {
-  const images = await getProjectImages("headless-ecommerce-mini-store");
-  const fallback = ["/static/placeholders/next.png"];
+  const alt = "Headless E-Commerce Mini-Store screenshot";
+  const images = (await getProjectImages("headless-ecommerce-mini-store")).map(
+    (src) => ({ src, alt })
+  );
+  const fallback = [{ src: "/static/placeholders/next.png", alt }];
 
   return (
     <div className="space-y-12">
       <ProjectOverview
         title="Headless E-Commerce Mini-Store"
         images={images.length ? images : fallback}
-        alt="Headless E-Commerce Mini-Store screenshot"
       >
         <p>
           <strong>Overview:</strong> Shop‑Next is a Next.js storefront that
@@ -70,7 +72,7 @@ export default async function HeadlessEcommerceMiniStore() {
 
       {images.length > 0 && (
         <ProjectSection title="Screenshots">
-          <ProjectGallery images={images} alt="Headless E-Commerce Mini-Store screenshots" />
+          <ProjectGallery images={images} />
         </ProjectSection>
       )}
     </div>

--- a/components/project-details/ItineraryPlanner.tsx
+++ b/components/project-details/ItineraryPlanner.tsx
@@ -4,14 +4,21 @@ import ProjectGallery from "./ProjectGallery";
 import { getProjectImages } from "@/lib/project-images";
 
 export default async function ItineraryPlanner() {
-  const images = await getProjectImages("itinerary-planner");
+  const alt = "Itinerary Planner screenshot";
+  const images = (await getProjectImages("itinerary-planner")).map((src) => ({
+    src,
+    alt,
+  }));
   const doubledImages = images.flatMap((img) => [img, img]);
   return (
     <div className="space-y-12">
       <ProjectOverview
         title="Itinerary Planner"
-        images={doubledImages.length ? doubledImages : ["/static/placeholders/php.png"]}
-        alt="Itinerary Planner screenshot"
+        images={
+          doubledImages.length
+            ? doubledImages
+            : [{ src: "/static/placeholders/php.png", alt }]
+        }
         githubUrl="https://github.com/Seanneskie/itinerary-planner"
       >
         <p>
@@ -151,7 +158,7 @@ php artisan serve`}</pre>
 
       {doubledImages.length > 0 && (
         <ProjectSection title="Screenshots">
-          <ProjectGallery images={doubledImages} alt="Itinerary Planner screenshot" />
+          <ProjectGallery images={doubledImages} />
         </ProjectSection>
       )}
     </div>

--- a/components/project-details/McdonaldsSentimentAnalysis.tsx
+++ b/components/project-details/McdonaldsSentimentAnalysis.tsx
@@ -6,15 +6,21 @@ import { getProjectPdfs } from "@/lib/project-pdfs";
 import { withBasePath } from "@/lib/utils";
 
 export default async function McdonaldsSentimentAnalysis() {
-  const images = await getProjectImages("mcdonalds-sentiment-analysis");
+  const alt = "McDonald's Sentiment Analysis screenshot";
+  const images = (
+    await getProjectImages("mcdonalds-sentiment-analysis")
+  ).map((src) => ({ src, alt }));
   const pdfs = await getProjectPdfs("mcdonalds-sentiment-analysis");
   const pdf = pdfs[0];
   return (
     <div className="space-y-12">
       <ProjectOverview
         title="McDonald's Sentiment Analysis"
-        images={images.length ? images : ["/static/placeholders/django.png"]}
-        alt="McDonald&apos;s Sentiment Analysis screenshot"
+        images={
+          images.length
+            ? images
+            : [{ src: "/static/placeholders/django.png", alt }]
+        }
         downloadUrl={pdf}
       >
         <p>
@@ -138,10 +144,7 @@ export default async function McdonaldsSentimentAnalysis() {
 
       {images.length > 0 && (
         <ProjectSection title="Screenshots">
-          <ProjectGallery
-            images={images}
-            alt="McDonald&apos;s Sentiment Analysis screenshot"
-          />
+          <ProjectGallery images={images} />
         </ProjectSection>
       )}
     </div>

--- a/components/project-details/NosqlProject.tsx
+++ b/components/project-details/NosqlProject.tsx
@@ -4,13 +4,20 @@ import ProjectGallery from "./ProjectGallery";
 import { getProjectImages } from "@/lib/project-images";
 
 export default async function NosqlProject() {
-  const images = await getProjectImages("nosql-project");
+  const alt = "NoSQL Project screenshot";
+  const images = (await getProjectImages("nosql-project")).map((src) => ({
+    src,
+    alt,
+  }));
   return (
     <div className="space-y-12">
       <ProjectOverview
         title="NoSQL Project - MERN Stack Website"
-        images={images.length ? images : ["/static/placeholders/Mern.png"]}
-        alt="NoSQL Project screenshot"
+        images={
+          images.length
+            ? images
+            : [{ src: "/static/placeholders/Mern.png", alt }]
+        }
       >
         <p>
           <strong>Overview:</strong> CoffeeHub is a full-stack web application
@@ -93,7 +100,7 @@ export default async function NosqlProject() {
 
       {images.length > 0 && (
         <ProjectSection title="Screenshots">
-          <ProjectGallery images={images} alt="NoSQL Project screenshot" />
+          <ProjectGallery images={images} />
         </ProjectSection>
       )}
     </div>

--- a/components/project-details/OrderInventoryManagementApi.tsx
+++ b/components/project-details/OrderInventoryManagementApi.tsx
@@ -4,13 +4,19 @@ import ProjectGallery from "./ProjectGallery";
 import { getProjectImages } from "@/lib/project-images";
 
 export default async function OrderInventoryManagementApi() {
-  const images = await getProjectImages("order-inventory-management-api");
+  const alt = "Order & Inventory Management API screenshot";
+  const images = (await getProjectImages("order-inventory-management-api")).map(
+    (src) => ({ src, alt })
+  );
   return (
     <div className="space-y-12">
       <ProjectOverview
         title="Order & Inventory Management API"
-        images={images.length ? images : ["/static/placeholders/next.png"]}
-        alt="Order & Inventory Management API screenshot"
+        images={
+          images.length
+            ? images
+            : [{ src: "/static/placeholders/next.png", alt }]
+        }
       >
         <p>
           <strong>Overview:</strong> Lightweight RESTful API built with ASP.NET Core
@@ -46,7 +52,7 @@ export default async function OrderInventoryManagementApi() {
 
       {images.length > 0 && (
         <ProjectSection title="Screenshots">
-          <ProjectGallery images={images} alt="Order & Inventory Management API screenshot" />
+          <ProjectGallery images={images} />
         </ProjectSection>
       )}
     </div>

--- a/components/project-details/ProjectGallery.tsx
+++ b/components/project-details/ProjectGallery.tsx
@@ -16,8 +16,7 @@ import {
 import { AspectRatio } from "@/components/ui/aspect-ratio";
 
 interface ProjectGalleryProps {
-  images: string[];
-  alt: string;
+  images: Array<{ src: string; alt: string }>;
   showThumbnails?: boolean;
   className?: string;
   enableLightbox?: boolean;
@@ -25,7 +24,6 @@ interface ProjectGalleryProps {
 
 export default function ProjectGallery({
   images,
-  alt,
   showThumbnails = true,
   className,
   enableLightbox = true,
@@ -81,8 +79,8 @@ export default function ProjectGallery({
 
         <Carousel className="w-full" opts={{ loop: true, align: "start", duration: 16 }} setApi={setApi}>
           <CarouselContent className="ml-0">
-            {images.map((src, i) => (
-              <CarouselItem key={src} className="basis-full">
+            {images.map((img, i) => (
+              <CarouselItem key={img.src} className="basis-full">
                 <motion.figure
                   className="relative overflow-hidden rounded-xl ring-1 ring-black/5 dark:ring-white/10"
                   initial={{ opacity: 0, scale: 0.98 }}
@@ -91,8 +89,8 @@ export default function ProjectGallery({
                 >
                   <AspectRatio ratio={4 / 3} className="bg-muted/40">
                     <Image
-                      src={withBasePath(src)}
-                      alt={`${alt} (${i + 1}/${images.length})`}
+                      src={withBasePath(img.src)}
+                      alt={`${img.alt} (${i + 1}/${images.length})`}
                       fill
                       sizes="(max-width: 640px) 100vw, (max-width: 1024px) 80vw, 960px"
                       priority={i === 0}
@@ -130,9 +128,9 @@ export default function ProjectGallery({
         {/* Thumbnails */}
         {showThumbnails && images.length > 1 && (
           <div className="mt-4 flex gap-2 overflow-x-auto pb-1">
-            {images.map((src, i) => (
+            {images.map((img, i) => (
               <button
-                key={`thumb-${src}`}
+                key={`thumb-${img.src}`}
                 onClick={() => api?.scrollTo(i)}
                 className={cn(
                   "relative h-16 w-24 flex-shrink-0 overflow-hidden rounded-lg ring-1 ring-black/5 transition",
@@ -140,7 +138,7 @@ export default function ProjectGallery({
                 )}
                 aria-label={`View thumbnail ${i + 1}`}
               >
-                <Image src={withBasePath(src)} alt={`${alt} thumbnail ${i + 1}`} fill className="object-cover" sizes="96px" draggable={false} />
+                <Image src={withBasePath(img.src)} alt={img.alt} fill className="object-cover" sizes="96px" draggable={false} />
               </button>
             ))}
           </div>
@@ -150,7 +148,6 @@ export default function ProjectGallery({
       <Lightbox
         images={images}
         startIndex={index}
-        alt={alt}
         open={lightboxOpen}
         onClose={() => setLightboxOpen(false)}
         onIndexChange={(i) => {
@@ -169,14 +166,12 @@ export default function ProjectGallery({
 function Lightbox({
   images,
   startIndex = 0,
-  alt,
   open,
   onClose,
   onIndexChange,
 }: {
-  images: string[];
+  images: Array<{ src: string; alt: string }>;
   startIndex?: number;
-  alt: string;
   open: boolean;
   onClose: () => void;
   onIndexChange?: (index: number) => void;
@@ -344,9 +339,9 @@ function Lightbox({
             style={{ touchAction: "none" }}
           >
             <Image
-              key={images[index]}
-              src={withBasePath(images[index])}
-              alt={`${alt} (zoomed ${index + 1}/${images.length})`}
+              key={images[index].src}
+              src={withBasePath(images[index].src)}
+              alt={`${images[index].alt} (zoomed ${index + 1}/${images.length})`}
               fill
               sizes="100vw"
               className="pointer-events-none object-contain"

--- a/components/project-details/ProjectHtml.tsx
+++ b/components/project-details/ProjectHtml.tsx
@@ -8,7 +8,8 @@ interface ProjectHtmlProps {
 }
 
 export default async function ProjectHtml({ slug }: ProjectHtmlProps) {
-  const images = await getProjectImages(slug);
+  const alt = `${slug} screenshot`;
+  const images = (await getProjectImages(slug)).map((src) => ({ src, alt }));
   const filePath = path.join(process.cwd(), "public", "project-details", `${slug}.html`);
 
   let html = "";
@@ -20,9 +21,7 @@ export default async function ProjectHtml({ slug }: ProjectHtmlProps) {
 
   return (
     <div className="space-y-6">
-      {images.length > 0 && (
-        <ProjectGallery images={images} alt={`${slug} screenshot`} />
-      )}
+      {images.length > 0 && <ProjectGallery images={images} />}
       <div dangerouslySetInnerHTML={{ __html: html }} />
     </div>
   );

--- a/components/project-details/ProjectOverview.tsx
+++ b/components/project-details/ProjectOverview.tsx
@@ -8,8 +8,7 @@ import { FileText, Github } from "lucide-react";
 
 interface ProjectOverviewProps {
   title: string;
-  images: string[];
-  alt: string;
+  images: Array<{ src: string; alt: string }>;
   children: ReactNode;
   githubUrl?: string;
   linkLabel?: string;
@@ -19,7 +18,6 @@ interface ProjectOverviewProps {
 export default function ProjectOverview({
   title,
   images,
-  alt,
   children,
   githubUrl,
   linkLabel = "View on GitHub",
@@ -33,12 +31,12 @@ export default function ProjectOverview({
     >
       <div className="relative mb-4 md:mb-0">
         {images.length > 1 ? (
-          <ProjectGallery images={images} alt={alt} />
+          <ProjectGallery images={images} />
         ) : (
           <div className="relative aspect-video overflow-hidden rounded-xl">
             <Image
-              src={withBasePath(firstImage)}
-              alt={alt}
+              src={withBasePath(firstImage.src)}
+              alt={firstImage.alt}
               fill
               className="object-cover"
             />

--- a/components/project-details/ProjectTemplate.tsx
+++ b/components/project-details/ProjectTemplate.tsx
@@ -3,13 +3,20 @@ import ProjectSection from "./ProjectSection";
 import ProjectGallery from "./ProjectGallery";
 import { getProjectImages } from "@/lib/project-images";
 export default async function ProjectTemplate() {
-  const images = await getProjectImages("project-slug");
+  const alt = "Project screenshot";
+  const images = (await getProjectImages("project-slug")).map((src) => ({
+    src,
+    alt,
+  }));
   return (
     <div className="space-y-12">
       <ProjectOverview
         title="Project Title"
-        images={images.length ? images : ["/static/placeholders/ai.png"]}
-        alt="Project screenshot"
+        images={
+          images.length
+            ? images
+            : [{ src: "/static/placeholders/ai.png", alt }]
+        }
         // githubUrl="https://github.com/username/repo" // optional
         // downloadUrl="/static/project-slug/file.zip" // optional
       >
@@ -51,7 +58,7 @@ export default async function ProjectTemplate() {
 
       {images.length > 0 && (
         <ProjectSection title="Screenshots">
-          <ProjectGallery images={images} alt="Project screenshot" />
+          <ProjectGallery images={images} />
         </ProjectSection>
       )}
     </div>

--- a/components/project-details/Vims.tsx
+++ b/components/project-details/Vims.tsx
@@ -4,13 +4,20 @@ import ProjectGallery from "./ProjectGallery";
 import { getProjectImages } from "@/lib/project-images";
 
 export default async function Vims() {
-  const images = await getProjectImages("vims");
+  const alt = "Vessel Inventory Management System screenshot";
+  const images = (await getProjectImages("vims")).map((src) => ({
+    src,
+    alt,
+  }));
   return (
     <div className="space-y-12">
       <ProjectOverview
         title="Vessel Inventory Management System"
-        images={images.length ? images : ["/static/placeholders/next.png"]}
-        alt="Vessel Inventory Management System screenshot"
+        images={
+          images.length
+            ? images
+            : [{ src: "/static/placeholders/next.png", alt }]
+        }
       >
         <p>
           <strong>Overview:</strong> VIMS is a vessel‑oriented inventory
@@ -86,7 +93,7 @@ export default async function Vims() {
 
       {images.length > 0 && (
         <ProjectSection title="Screenshots">
-          <ProjectGallery images={images} alt="Vessel Inventory Management System screenshot" />
+          <ProjectGallery images={images} />
         </ProjectSection>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Use `{src, alt}` objects for `ProjectGallery` images and update lightbox
- Drop global alt from `ProjectOverview` and display first image directly
- Adapt all project detail pages to supply image objects

## Testing
- `npm run lint`
- `npm test` *(fails: Failed to resolve import "@/components/awards" from "app/awards/page.tsx". Does the file exist?)*

------
https://chatgpt.com/codex/tasks/task_e_68b924c8d374832999c1df700a656ded