### PR TITLE
fix: correct work experience image paths

### DIFF
--- a/public/data/work-experiences.json
+++ b/public/data/work-experiences.json
@@ -31,8 +31,8 @@
     "project": "Cooperative Profiling & Fund Utilization System",
     "period": "January 2025 – April 2025",
     "images": [
-      { "src": "/cemcdo-app/images/Landing Page.png", "alt": "CEMCDO landing page" },
-      { "src": "/cemcdo-app/images/Admin Dashboard.png", "alt": "CEMCDO admin dashboard" }
+      { "src": "/cemcdo-app/images/landing-page.png", "alt": "CEMCDO landing page" },
+      { "src": "/cemcdo-app/images/admin-dashboard.png", "alt": "CEMCDO admin dashboard" }
     ],
     "tech": [
       "Django",


### PR DESCRIPTION
## Summary
- fix casing and spacing for work experience image names

## Testing
- `npm run lint`
- `npm test` *(fails: Failed to resolve import "@/components/awards" from "app/awards/page.tsx". Does the file exist?)*

------
https://chatgpt.com/codex/tasks/task_e_68b930857e448329a0cc213c8643e972