### PR TITLE
feat: add contact page and link

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,0 +1,38 @@
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { saveMessage } from "@/lib/contact";
+
+async function submitContact(formData: FormData) {
+  "use server";
+  const name = formData.get("name")?.toString() ?? "";
+  const email = formData.get("email")?.toString() ?? "";
+  const message = formData.get("message")?.toString() ?? "";
+
+  await saveMessage({ name, email, message });
+}
+
+export default function ContactPage() {
+  return (
+    <main className="container mx-auto max-w-2xl px-4 py-12">
+      <h1 className="mb-6 text-3xl font-bold">Contact</h1>
+      <form action={submitContact} className="space-y-6">
+        <div className="space-y-2">
+          <Label htmlFor="name">Name</Label>
+          <Input id="name" name="name" required />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="email">Email</Label>
+          <Input id="email" name="email" type="email" required />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="message">Message</Label>
+          <Textarea id="message" name="message" required />
+        </div>
+        <Button type="submit" className="w-full">Send</Button>
+      </form>
+    </main>
+  );
+}
+

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -36,12 +36,12 @@ export default function HomePage() {
             >
               View Resume
             </a>
-            <a
-              href="mailto:seannecanete32@gmail.com"
+            <Link
+              href="/contact"
               className="inline-flex items-center rounded-xl px-5 py-2.5 bg-teal-500/90 text-white hover:bg-teal-500 transition shadow"
             >
               Contact Me
-            </a>
+            </Link>
           </>
         }
       />

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -21,6 +21,7 @@ const NAV_LINKS = [
   { href: "/certificates", label: "Certificates" },
   { href: "/awards", label: "Awards" },
   { href: "/work-experiences", label: "Work Experiences" },
+  { href: "/contact", label: "Contact" },
   {
     href: withBasePath("/static/pdfs/canete_resume.pdf"),
     label: "Resume",

--- a/lib/contact.ts
+++ b/lib/contact.ts
@@ -1,0 +1,17 @@
+export type ContactMessage = {
+  name: string;
+  email: string;
+  message: string;
+  date: string;
+};
+
+const messages: ContactMessage[] = [];
+
+export async function saveMessage(data: Omit<ContactMessage, "date">) {
+  messages.push({ ...data, date: new Date().toISOString() });
+}
+
+export function getMessages() {
+  return messages;
+}
+


### PR DESCRIPTION
## Summary
- add contact page with message form
- store contact messages on the server
- link contact page from header and home banner

## Testing
- `npm run lint`
- `npm test` *(fails: Failed to resolve import "@/components/awards" from "app/awards/page.tsx")*

------
https://chatgpt.com/codex/tasks/task_e_68b93b7c14f08329bcf5c38d3d98464c