### PR TITLE
feat: show key skills on profile card

### DIFF
--- a/components/profile/ProfileCardContent.tsx
+++ b/components/profile/ProfileCardContent.tsx
@@ -5,6 +5,7 @@ import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { useData } from "@/lib/use-data";
 import {
   Copy,
   Mail,
@@ -30,6 +31,22 @@ import type { ProfileData, Links } from "./types";
 import { TooltipArrow } from "@radix-ui/react-tooltip";
 import Image from "next/image";
 import { withBasePath } from "@/lib/utils";
+
+interface SkillItem {
+  icon: string;
+  name: string;
+}
+
+interface SkillGroup {
+  title: string;
+  items: SkillItem[];
+}
+
+interface SkillCategory {
+  id: string;
+  label: string;
+  groups: SkillGroup[];
+}
 
 const socialList: { key: keyof Links; label: string; icon: LucideIcon }[] = [
   { key: "linkedin", label: "LinkedIn", icon: Linkedin },
@@ -58,6 +75,21 @@ export default function ProfileCardContent({ profile }: { profile: ProfileData }
   const major = info.major ?? info.specialization ?? "Database Systems Major";
   const phone =
     info.phone ?? info.contact ?? info.contactNo ?? info.contact_number ?? null;
+
+  const { data } = useData<SkillCategory[]>("skills.json");
+  const programming = data?.find(
+    (category) => category.id === "Programming"
+  );
+  const keySkills: SkillItem[] = [];
+  if (programming) {
+    const items = programming.groups.flatMap((group) => group.items);
+    for (const item of items) {
+      if (!keySkills.some((s) => s.name === item.name)) {
+        keySkills.push(item);
+      }
+      if (keySkills.length >= 5) break;
+    }
+  }
 
   return (
     <Card className="relative overflow-hidden">
@@ -177,6 +209,26 @@ export default function ProfileCardContent({ profile }: { profile: ProfileData }
                   Hire Me
                 </Button>
               </div>
+
+              {keySkills.length > 0 && (
+                <div>
+                  <p className="text-sm font-medium text-black/80 dark:text-white/80">
+                    Key Skills
+                  </p>
+                  <div className="mt-2 flex flex-wrap gap-2">
+                    {keySkills.map((skill) => (
+                      <Badge
+                        key={skill.name}
+                        variant="secondary"
+                        className="flex items-center gap-1 rounded-full"
+                      >
+                        <i className={skill.icon} />
+                        {skill.name}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+              )}
             </div>
 
             <Separator />


### PR DESCRIPTION
## Summary
- show top five skills on ProfileCard using data from skills.json
- style skill badges to match StorySkills

## Testing
- `npm run lint`
- `npm test` *(fails: Failed to resolve import "@/components/awards" from "app/awards/page.tsx")*

------
https://chatgpt.com/codex/tasks/task_e_68b93ba1301083298bdde5344ba590e5