### PR TITLE
fix nav link typing and update hero project link

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,12 +21,12 @@ export default function HomePage() {
         parallax
         actions={
           <>
-            <a
-              href="#projects"
+            <Link
+              href="/projects"
               className="inline-flex items-center rounded-xl px-5 py-2.5 bg-white/90 text-gray-900 hover:bg-white transition shadow"
             >
               View Projects
-            </a>
+            </Link>
             <a
               href={withBasePath("/static/pdfs/canete_resume.pdf")}
               target="_blank"

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -15,6 +15,12 @@ import { Github, Linkedin, Twitter } from "lucide-react";
 import { withBasePath } from "@/lib/utils";
 import { toast } from "sonner";
 
+type NavLink = {
+  href: string;
+  label: string;
+  external?: boolean;
+};
+
 const NAV_LINKS = [
   { href: "/", label: "Home" },
   { href: "/projects", label: "Projects" },
@@ -28,7 +34,7 @@ const NAV_LINKS = [
     label: "Resume",
     external: true,
   },
-] as const;
+] as const satisfies readonly NavLink[];
 
 const SOCIAL_LINKS = [
   {


### PR DESCRIPTION
## Summary
- add NavLink type with optional external flag for nav menu
- link hero 'View Projects' action to projects page

## Testing
- `npm run lint`
- `npm test` *(fails: Failed to resolve import "@/components/awards" from "app/awards/page.tsx")*

------
https://chatgpt.com/codex/tasks/task_e_68b93e47d15c8329950d9ded0f35b7ab