### PR TITLE
Handle optional external flag in nav links

### DIFF
--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -84,7 +84,8 @@ export default function Header() {
                 "group-hover:[&>li:not(:hover)]:scale-95",
               ].join(" ")}
             >
-              {NAV_LINKS.map(({ href, label, external }) => {
+              {NAV_LINKS.map((link: NavLink) => {
+                const { href, label, external } = link;
                 const isActive =
                   !external && (pathname === href || (href !== "/" && pathname?.startsWith(href)));
                 const isHot = hovered === href || isActive;


### PR DESCRIPTION
## Summary
- fix type error by typing navigation link mapping

## Testing
- `npm run lint`
- `npm test` *(fails: Failed to resolve import "@/components/awards" from "app/awards/page.tsx")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b941c2e29883298f75ba6683b09eb7