### PR TITLE
Refactor contact form to support static export

### DIFF
--- a/app/awards/page.test.tsx
+++ b/app/awards/page.test.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act } from "react-dom/test-utils";
 import { createRoot } from "react-dom/client";
@@ -20,6 +21,14 @@ describe("AwardsPage", () => {
             ]),
         })
       )
+    );
+    vi.stubGlobal(
+      "IntersectionObserver",
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      }
     );
   });
 

--- a/app/awards/page.tsx
+++ b/app/awards/page.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import Awards from "@/components/awards";
 
 export default function AwardsPage() {

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,37 +1,49 @@
+"use client";
+
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { saveMessage } from "@/lib/contact";
 
-async function submitContact(formData: FormData) {
-  "use server";
-  const name = formData.get("name")?.toString() ?? "";
-  const email = formData.get("email")?.toString() ?? "";
-  const message = formData.get("message")?.toString() ?? "";
-
-  await saveMessage({ name, email, message });
-}
-
 export default function ContactPage() {
+  const [submitted, setSubmitted] = useState(false);
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    const name = formData.get("name")?.toString() ?? "";
+    const email = formData.get("email")?.toString() ?? "";
+    const message = formData.get("message")?.toString() ?? "";
+    await saveMessage({ name, email, message });
+    setSubmitted(true);
+  }
+
   return (
     <main className="container mx-auto max-w-2xl px-4 py-12">
       <h1 className="mb-6 text-3xl font-bold">Contact</h1>
-      <form action={submitContact} className="space-y-6">
-        <div className="space-y-2">
-          <Label htmlFor="name">Name</Label>
-          <Input id="name" name="name" required />
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="email">Email</Label>
-          <Input id="email" name="email" type="email" required />
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="message">Message</Label>
-          <Textarea id="message" name="message" required />
-        </div>
-        <Button type="submit" className="w-full">Send</Button>
-      </form>
+      {submitted ? (
+        <p>Thanks for your message!</p>
+      ) : (
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <div className="space-y-2">
+            <Label htmlFor="name">Name</Label>
+            <Input id="name" name="name" required />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="email">Email</Label>
+            <Input id="email" name="email" type="email" required />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="message">Message</Label>
+            <Textarea id="message" name="message" required />
+          </div>
+          <Button type="submit" className="w-full">
+            Send
+          </Button>
+        </form>
+      )}
     </main>
   );
 }

--- a/components/awards/Awards.tsx
+++ b/components/awards/Awards.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import React from "react";
 import { motion, type Variants, type Transition } from "framer-motion";
 import { Card, CardContent } from "@/components/ui/card";
 import { useData } from "@/lib/use-data";

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from "vitest/config";
+import path from "path";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./"),
+    },
+  },
   test: {
     environment: "jsdom",
   },


### PR DESCRIPTION
## Summary
- replace contact form server action with client-side handler
- add vitest alias and polyfills for tests
- ensure awards components import React for vitest

## Testing
- `npm run lint`
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b945d482648329bd936b1eb374248e