### PR TITLE
feat: expand contact message type

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import { saveMessage } from "@/lib/contact";
+import { saveMessage } from "@/lib";
 
 export default function ContactPage() {
   const [submitted, setSubmitted] = useState(false);

--- a/lib/contact.ts
+++ b/lib/contact.ts
@@ -2,13 +2,18 @@ export type ContactMessage = {
   name: string;
   email: string;
   message: string;
+  subject?: string;
+  position?: string;
+  salaryRange?: string;
+  company?: string;
+  recruiterContact?: string;
   date: string;
 };
 
 const messages: ContactMessage[] = [];
 
-export async function saveMessage(data: Omit<ContactMessage, "date">) {
-  messages.push({ ...data, date: new Date().toISOString() });
+export async function saveMessage(message: Omit<ContactMessage, "date">) {
+  messages.push({ ...message, date: new Date().toISOString() });
 }
 
 export function getMessages() {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,0 +1,2 @@
+export { saveMessage, getMessages } from "./contact";
+export type { ContactMessage } from "./contact";


### PR DESCRIPTION
## Summary
- extend contact message to handle optional recruiter and job fields
- add barrel export for contact utilities
- use barrel export in contact page

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b955c0e41c832981f8316cb2dff141