### PR TITLE
feat: add contact info section

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -2,13 +2,27 @@
 
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { useData } from "@/lib/use-data";
 import { saveMessage } from "@/lib";
+import { Github, Linkedin, Mail, Phone, Twitter } from "lucide-react";
+
+interface ContactInfo {
+  email: string;
+  phone: string;
+  socials?: {
+    linkedin?: string;
+    github?: string;
+    twitter?: string;
+  };
+}
 
 export default function ContactPage() {
   const [submitted, setSubmitted] = useState(false);
+  const { data: profile } = useData<ContactInfo>("profile.json");
 
   async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -23,6 +37,91 @@ export default function ContactPage() {
   return (
     <main className="container mx-auto max-w-2xl px-4 py-12">
       <h1 className="mb-6 text-3xl font-bold">Contact</h1>
+      {profile && (
+        <section aria-labelledby="contact-info" className="mb-8">
+          <Card>
+            <CardHeader>
+              <CardTitle id="contact-info">Contact Information</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="flex items-center gap-2">
+                <Mail className="h-5 w-5 text-teal-600" aria-hidden="true" />
+                <Button
+                  asChild
+                  variant="link"
+                  className="h-auto p-0 text-teal-600"
+                >
+                  <a href={`mailto:${profile.email}`}>{profile.email}</a>
+                </Button>
+              </div>
+              <div className="flex items-center gap-2">
+                <Phone className="h-5 w-5 text-teal-600" aria-hidden="true" />
+                <Button
+                  asChild
+                  variant="link"
+                  className="h-auto p-0 text-teal-600"
+                >
+                  <a href={`tel:${profile.phone}`}>{profile.phone}</a>
+                </Button>
+              </div>
+              <div
+                className="flex items-center gap-2"
+                role="group"
+                aria-label="Social links"
+              >
+                {profile.socials?.linkedin && (
+                  <Button
+                    asChild
+                    variant="outline"
+                    className="border-teal-600 text-teal-600 hover:bg-teal-500/20"
+                  >
+                    <a
+                      href={profile.socials.linkedin}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      aria-label="LinkedIn"
+                    >
+                      <Linkedin className="h-4 w-4" aria-hidden="true" />
+                    </a>
+                  </Button>
+                )}
+                {profile.socials?.github && (
+                  <Button
+                    asChild
+                    variant="outline"
+                    className="border-teal-600 text-teal-600 hover:bg-teal-500/20"
+                  >
+                    <a
+                      href={profile.socials.github}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      aria-label="GitHub"
+                    >
+                      <Github className="h-4 w-4" aria-hidden="true" />
+                    </a>
+                  </Button>
+                )}
+                {profile.socials?.twitter && (
+                  <Button
+                    asChild
+                    variant="outline"
+                    className="border-teal-600 text-teal-600 hover:bg-teal-500/20"
+                  >
+                    <a
+                      href={profile.socials.twitter}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      aria-label="Twitter"
+                    >
+                      <Twitter className="h-4 w-4" aria-hidden="true" />
+                    </a>
+                  </Button>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        </section>
+      )}
       {submitted ? (
         <p>Thanks for your message!</p>
       ) : (

--- a/public/data/profile.json
+++ b/public/data/profile.json
@@ -1,5 +1,12 @@
 {
   "name": "Seanne Cañete",
   "headline": "Full Stack Developer",
-  "bio": "Passionate developer building web and AI solutions."
+  "bio": "Passionate developer building web and AI solutions.",
+  "email": "seannecanete32@gmail.com",
+  "phone": "+63 912 345 6789",
+  "socials": {
+    "linkedin": "https://www.linkedin.com/in/seanne-ca%C3%B1ete-8b09322a1/",
+    "github": "https://github.com/Seanneskie",
+    "twitter": "https://x.com/Seanneskie"
+  }
 }


### PR DESCRIPTION
## Summary
- extend profile data with contact details
- show email, phone, and socials on Contact page using `useData`

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b95a4f70f8832995627dd067c2dfa3