### PR TITLE
docs: expand API project section

### DIFF
--- a/components/project-details/OrderInventoryManagementApi.tsx
+++ b/components/project-details/OrderInventoryManagementApi.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import ProjectOverview from "./ProjectOverview";
 import ProjectSection from "./ProjectSection";
 import ProjectGallery from "./ProjectGallery";
@@ -35,8 +36,10 @@ export default async function OrderInventoryManagementApi() {
 
       <ProjectSection title="Introduction">
         <p>
-          Lightweight ASP.NET Core and PostgreSQL service offering product CRUD,
-          stock validation, and idempotent order placement for small stores.
+          Lightweight ASP.NET Core (net8.0) service using Entity Framework Core
+          with the Npgsql provider to talk to a local PostgreSQL database. It
+          offers product CRUD, stock validation, and idempotent order placement
+          for small stores.
         </p>
       </ProjectSection>
       <ProjectSection title="Consistency and Concurrency">
@@ -47,10 +50,13 @@ export default async function OrderInventoryManagementApi() {
       </ProjectSection>
       <ProjectSection title="Development and Deployment">
         <p>
-          EF Core migrations, FluentValidation, RFC 7807 <code>ProblemDetails</code>,
-          Swagger, and Serilog support robust development. Integration tests run
-          against a Dockerized Postgres instance and the API targets Azure
-          hosting.
+          NuGet packages like FluentValidation.AspNetCore, Microsoft.AspNetCore.OpenApi,
+          Npgsql.EntityFrameworkCore.PostgreSQL, Serilog.AspNetCore with a console
+          sink, and Swashbuckle.AspNetCore power the API. The default connection
+          string points at a local PostgreSQL instance but can be overridden for
+          other environments. EF Core migrations, RFC 7807 <code>ProblemDetails</code>,
+          and integration tests against Dockerized Postgres prepare the project
+          for Azure deployment.
         </p>
       </ProjectSection>
 

--- a/components/project-details/order-inventory-management-api.test.tsx
+++ b/components/project-details/order-inventory-management-api.test.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { act } from "react-dom/test-utils";
+import { createRoot } from "react-dom/client";
+import OrderInventoryManagementApi from "./OrderInventoryManagementApi";
+
+vi.mock("@/lib/project-images", () => ({
+  getProjectImages: vi.fn(async () => [])
+}));
+
+// Ensure React is globally available for components compiled with the new JSX runtime
+(globalThis as { React?: typeof React }).React = React;
+describe("OrderInventoryManagementApi", () => {
+  it("mentions local PostgreSQL connection", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(await OrderInventoryManagementApi());
+    });
+
+    expect(container.textContent).toContain("local PostgreSQL");
+
+    root.unmount();
+    container.remove();
+  });
+});

--- a/public/project-details/order-inventory-management-api.html
+++ b/public/project-details/order-inventory-management-api.html
@@ -12,9 +12,9 @@
 <body>
   <h1>Order & Inventory Management API</h1>
   <img src="/static/placeholders/c%23.png" alt="Order & Inventory Management API screenshot" />
-  <p>Lightweight ASP.NET Core and PostgreSQL service providing product CRUD, stock validation, and idempotent order placement.</p>
+  <p>Lightweight ASP.NET Core (net8.0) service using Entity Framework Core with the Npgsql provider to talk to a local PostgreSQL database. It offers product CRUD, stock validation, and idempotent order placement for small stores.</p>
   <p>Transactional updates with an inventory audit log ensure consistency while Postgres <code>xmin</code> optimistic concurrency prevents oversells.</p>
-  <p>EF Core migrations, FluentValidation, RFC 7807 <code>ProblemDetails</code>, Swagger, and Serilog support robust development. Integration tests run against a Dockerized Postgres instance and the API is designed for Azure deployment.</p>
+  <p>NuGet packages like FluentValidation.AspNetCore, Microsoft.AspNetCore.OpenApi, Npgsql.EntityFrameworkCore.PostgreSQL, Serilog.AspNetCore with a console sink, and Swashbuckle.AspNetCore power the API. The default connection string points at a local PostgreSQL instance but can be overridden for other environments. EF Core migrations, RFC 7807 <code>ProblemDetails</code>, and integration tests against Dockerized Postgres prepare the project for Azure deployment.</p>
   <p><a href="https://github.com/Seanneskie/dotnet-inventory">View on GitHub</a></p>
   <p><em>This is a hobby/learning project only.</em></p>
 </body>


### PR DESCRIPTION
## Summary
- expand Order & Inventory Management API details with package and local PostgreSQL info
- mirror discussion in static HTML fallback
- add unit test for project detail component

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7c9673f448329aa99b14ca7880eeb