### PR TITLE
Add skill stats hooks and counter UI

### DIFF
--- a/components/profile/skill-counter-card.test.tsx
+++ b/components/profile/skill-counter-card.test.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { act } from "react-dom/test-utils";
+import { createRoot } from "react-dom/client";
+import SkillCounterCard from "./skill-counter-card";
+
+vi.mock("@/components/ui/card", () => ({
+  Card: ({ children, ...props }: { children: React.ReactNode }) => (
+    <div {...props}>{children}</div>
+  ),
+  CardContent: ({ children, ...props }: { children: React.ReactNode }) => (
+    <div {...props}>{children}</div>
+  ),
+}));
+
+(globalThis as { React?: typeof React }).React = React;
+
+describe("SkillCounterCard", () => {
+  it("renders name and count", () => {
+    const container = document.createElement("div");
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(<SkillCounterCard name="React" count={3} />);
+    });
+
+    const heading = container.querySelector("h3");
+    const count = container.querySelector("p");
+
+    expect(heading?.textContent).toBe("React");
+    expect(count?.textContent).toBe("3");
+
+    root.unmount();
+    container.remove();
+  });
+});

--- a/components/profile/skill-counter-card.tsx
+++ b/components/profile/skill-counter-card.tsx
@@ -1,0 +1,23 @@
+/**
+ * Usage:
+ * <SkillCounterCard name="React" count={3} />
+ */
+import { Card, CardContent } from "@/components/ui/card";
+
+export interface SkillCounterCardProps {
+  name: string;
+  count: number;
+}
+
+const SkillCounterCard: React.FC<SkillCounterCardProps> = ({ name, count }) => (
+  <Card className="border-teal-500">
+    <CardContent className="text-center">
+      <h3 className="text-lg font-semibold text-teal-700">{name}</h3>
+      <p className="text-2xl font-bold text-teal-600" aria-label={`${name} count`}>
+        {count}
+      </p>
+    </CardContent>
+  </Card>
+);
+
+export default SkillCounterCard;

--- a/components/profile/skill-counter-cards.test.tsx
+++ b/components/profile/skill-counter-cards.test.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { act } from "react-dom/test-utils";
+import { createRoot } from "react-dom/client";
+import SkillCounterCards from "./skill-counter-cards";
+
+vi.mock("@/hooks/use-skill-stats", () => ({
+  __esModule: true,
+  default: () => ({
+    stats: [{ name: "React", count: 2 }],
+    loading: false,
+    error: null,
+  }),
+}));
+
+vi.mock("./skill-counter-card", () => ({
+  __esModule: true,
+  default: ({ name, count }: { name: string; count: number }) => (
+    <div data-name={name}>{count}</div>
+  ),
+}));
+
+(globalThis as { React?: typeof React }).React = React;
+
+describe("SkillCounterCards", () => {
+  it("renders stats", () => {
+    const container = document.createElement("div");
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(<SkillCounterCards />);
+    });
+
+    const card = container.querySelector("[data-name='React']");
+    expect(card?.textContent).toBe("2");
+
+    root.unmount();
+    container.remove();
+  });
+});

--- a/components/profile/skill-counter-cards.tsx
+++ b/components/profile/skill-counter-cards.tsx
@@ -1,0 +1,26 @@
+/**
+ * Usage:
+ * <SkillCounterCards limit={6} />
+ */
+import useSkillStats from "@/hooks/use-skill-stats";
+import SkillCounterCard from "./skill-counter-card";
+
+export interface SkillCounterCardsProps {
+  limit?: number;
+}
+
+const SkillCounterCards: React.FC<SkillCounterCardsProps> = ({ limit = 6 }) => {
+  const { stats, loading, error } = useSkillStats();
+
+  if (loading || error) return null;
+
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3">
+      {stats.slice(0, limit).map((stat) => (
+        <SkillCounterCard key={stat.name} name={stat.name} count={stat.count} />
+      ))}
+    </div>
+  );
+};
+
+export default SkillCounterCards;

--- a/hooks/use-skill-stats.test.tsx
+++ b/hooks/use-skill-stats.test.tsx
@@ -1,0 +1,66 @@
+import React, { useEffect } from "react";
+import { describe, it, expect, vi } from "vitest";
+import { act } from "react-dom/test-utils";
+import { createRoot } from "react-dom/client";
+import useSkillStats from "./use-skill-stats";
+import type { SkillStat } from "@/types/skill";
+
+const projects = [
+  { tags: ["React", "TypeScript"] },
+  { tags: ["React"] },
+];
+
+const skills = [
+  {
+    id: "Programming",
+    label: "Programming",
+    groups: [
+      {
+        title: "Web",
+        items: [
+          { icon: "", name: "React" },
+          { icon: "", name: "TypeScript" },
+        ],
+      },
+    ],
+  },
+];
+
+vi.mock("@/lib/use-data", () => ({
+  useData: (file: string) => {
+    if (file === "projects.json")
+      return { data: projects, loading: false, error: null };
+    return { data: skills, loading: false, error: null };
+  },
+}));
+
+(globalThis as { React?: typeof React }).React = React;
+
+describe("useSkillStats", () => {
+  it("aggregates skill counts", () => {
+    let result: SkillStat[] = [];
+
+    const TestComponent = () => {
+      const { stats } = useSkillStats();
+      useEffect(() => {
+        result = stats;
+      }, [stats]);
+      return null;
+    };
+
+    const container = document.createElement("div");
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(<TestComponent />);
+    });
+
+    expect(result).toEqual([
+      { name: "React", count: 2 },
+      { name: "TypeScript", count: 1 },
+    ]);
+
+    root.unmount();
+    container.remove();
+  });
+});

--- a/hooks/use-skill-stats.ts
+++ b/hooks/use-skill-stats.ts
@@ -1,0 +1,64 @@
+import { useMemo } from "react";
+import { useData } from "@/lib/use-data";
+import type { SkillCategory, SkillStat } from "@/types/skill";
+
+interface Project {
+  tags: string[];
+}
+
+interface UseSkillStatsResult {
+  stats: SkillStat[];
+  loading: boolean;
+  error: Error | null;
+}
+
+/**
+ * Aggregates skill usage counts from project tags by matching them with known
+ * skills defined in `skills.json`.
+ */
+export default function useSkillStats(): UseSkillStatsResult {
+  const { data: projects, loading: projectsLoading, error: projectsError } =
+    useData<Project[]>("projects.json");
+  const { data: skills, loading: skillsLoading, error: skillsError } =
+    useData<SkillCategory[]>("skills.json");
+
+  const stats = useMemo<SkillStat[]>(() => {
+    if (!projects || !skills) return [];
+
+    const skillNames = new Map<string, string>();
+    skills.forEach((category) =>
+      category.groups.forEach((group) =>
+        group.items.forEach((item) => {
+          skillNames.set(item.name.toLowerCase(), item.name);
+        })
+      )
+    );
+
+    const counts: Record<string, number> = {};
+    projects.forEach((project) => {
+      project.tags.forEach((tag) => {
+        const tagKey = tag.toLowerCase();
+        const matched = Array.from(skillNames.keys()).find(
+          (name) =>
+            name === tagKey ||
+            name.includes(tagKey) ||
+            tagKey.includes(name)
+        );
+        if (matched) {
+          const displayName = skillNames.get(matched) as string;
+          counts[displayName] = (counts[displayName] || 0) + 1;
+        }
+      });
+    });
+
+    return Object.entries(counts)
+      .map(([name, count]) => ({ name, count }))
+      .sort((a, b) => b.count - a.count);
+  }, [projects, skills]);
+
+  return {
+    stats,
+    loading: projectsLoading || skillsLoading,
+    error: projectsError || skillsError,
+  };
+}

--- a/types/skill.ts
+++ b/types/skill.ts
@@ -1,0 +1,20 @@
+export interface SkillItem {
+  icon: string;
+  name: string;
+}
+
+export interface SkillGroup {
+  title: string;
+  items: SkillItem[];
+}
+
+export interface SkillCategory {
+  id: string;
+  label: string;
+  groups: SkillGroup[];
+}
+
+export interface SkillStat {
+  name: string;
+  count: number;
+}


### PR DESCRIPTION
## Summary
- compute skill usage totals from project tags via `useSkillStats`
- render teal accented stat cards in `SkillCounterCard` and grid wrapper
- add shared skill types and unit tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c80a7c11f48329aab7a83a8c9b4780