### PR TITLE
feat: add skills radar chart

### DIFF
--- a/components/profile/__tests__/skills-radar-chart.test.tsx
+++ b/components/profile/__tests__/skills-radar-chart.test.tsx
@@ -1,0 +1,35 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, beforeAll } from "vitest";
+import SkillsRadarChart from "@/components/profile/skills-radar-chart";
+import { SkillCategoryStats } from "@/hooks/use-skill-radar-data";
+
+const stats: SkillCategoryStats = {
+  language: { TypeScript: 80, JavaScript: 60 },
+  framework: { React: 70, Next: 50 },
+};
+
+beforeAll(() => {
+  // Recharts relies on ResizeObserver which isn't available in jsdom
+  class RO {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  }
+  (globalThis as unknown as { ResizeObserver: typeof RO }).ResizeObserver = RO;
+});
+
+describe("SkillsRadarChart", () => {
+  it("renders and switches categories", () => {
+    render(<SkillsRadarChart stats={stats} />);
+
+    // Initial category should be language
+    expect(screen.getByRole("combobox")).toHaveTextContent("language");
+    expect(screen.getByText("TypeScript")).toBeInTheDocument();
+
+    // Switch to framework
+    fireEvent.pointerDown(screen.getByRole("combobox"));
+    fireEvent.click(screen.getByRole("option", { name: "framework" }));
+
+    expect(screen.getByText("React")).toBeInTheDocument();
+  });
+});

--- a/components/profile/index.ts
+++ b/components/profile/index.ts
@@ -1,3 +1,4 @@
 export { default } from "./Profile";
 export { default as MyStory } from "./MyStory";
 export { default as AboutMe } from "./AboutMe";
+export { default as SkillsRadarChart } from "./skills-radar-chart";

--- a/components/profile/skills-radar-chart.tsx
+++ b/components/profile/skills-radar-chart.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useState } from "react";
+import {
+  ResponsiveContainer,
+  RadarChart,
+  PolarGrid,
+  PolarAngleAxis,
+  PolarRadiusAxis,
+  Radar,
+  Legend,
+} from "recharts";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import useSkillRadarData, {
+  SkillCategoryStats,
+} from "@/hooks/use-skill-radar-data";
+
+export interface SkillsRadarChartProps {
+  stats: SkillCategoryStats;
+}
+
+/**
+ * Displays developer skills in a radar chart with category filtering.
+ *
+ * @example
+ * ```tsx
+ * const stats = {
+ *   language: { TypeScript: 80, JavaScript: 60 },
+ *   framework: { React: 70, Next: 50 },
+ * };
+ * <SkillsRadarChart stats={stats} />
+ * ```
+ */
+export default function SkillsRadarChart({
+  stats,
+}: SkillsRadarChartProps): JSX.Element | null {
+  const [category, setCategory] = useState<string>(Object.keys(stats)[0] ?? "");
+  const { data, categories } = useSkillRadarData(stats, category);
+
+  if (!category) return null;
+
+  return (
+    <div className="space-y-4" aria-label="Skill radar chart section">
+      <Select value={category} onValueChange={setCategory}>
+        <SelectTrigger aria-label="Select skill category">
+          <SelectValue placeholder="Category" />
+        </SelectTrigger>
+        <SelectContent>
+          {categories.map((cat) => (
+            <SelectItem key={cat} value={cat}>
+              {cat}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <ResponsiveContainer width="100%" height={300}>
+        <RadarChart data={data} role="img" aria-label={`${category} proficiency radar chart`}>
+          <PolarGrid />
+          <PolarAngleAxis dataKey="skill" />
+          <PolarRadiusAxis />
+          <Radar
+            name={category}
+            dataKey="value"
+            stroke="#14b8a6"
+            fill="#14b8a6"
+            fillOpacity={0.4}
+          />
+          <Legend />
+        </RadarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/hooks/__tests__/use-skill-radar-data.test.ts
+++ b/hooks/__tests__/use-skill-radar-data.test.ts
@@ -1,0 +1,25 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import useSkillRadarData, { SkillCategoryStats } from "@/hooks/use-skill-radar-data";
+
+const stats: SkillCategoryStats = {
+  language: { TypeScript: 80, JavaScript: 60 },
+  framework: { React: 70 },
+};
+
+describe("useSkillRadarData", () => {
+  it("returns categories and transforms data", () => {
+    const { result, rerender } = renderHook(({ category }) => useSkillRadarData(stats, category), {
+      initialProps: { category: "language" },
+    });
+
+    expect(result.current.categories).toEqual(["language", "framework"]);
+    expect(result.current.data).toEqual([
+      { skill: "TypeScript", value: 80 },
+      { skill: "JavaScript", value: 60 },
+    ]);
+
+    rerender({ category: "framework" });
+    expect(result.current.data).toEqual([{ skill: "React", value: 70 }]);
+  });
+});

--- a/hooks/use-skill-radar-data.ts
+++ b/hooks/use-skill-radar-data.ts
@@ -1,0 +1,34 @@
+import { useMemo } from "react";
+
+export type SkillCategoryStats = Record<string, Record<string, number>>;
+
+export interface RadarDataPoint {
+  skill: string;
+  value: number;
+}
+
+/**
+ * Convert aggregated skill statistics into a dataset compatible with Recharts.
+ *
+ * @param stats - Aggregated statistics keyed by category then skill name.
+ * @param category - Active category to extract (e.g., "language").
+ * @returns Dataset for the chart and list of available categories.
+ */
+export function useSkillRadarData(
+  stats: SkillCategoryStats,
+  category: string
+): { data: RadarDataPoint[]; categories: string[] } {
+  const categories = useMemo<string[]>(() => Object.keys(stats), [stats]);
+
+  const data = useMemo<RadarDataPoint[]>(() => {
+    const current = stats[category] ?? {};
+    return Object.entries(current).map(([skill, value]) => ({
+      skill,
+      value,
+    }));
+  }, [stats, category]);
+
+  return { data, categories };
+}
+
+export default useSkillRadarData;

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "sonner": "^2.0.7",
-    "tailwind-merge": "^3.3.1"
+    "tailwind-merge": "^3.3.1",
+    "recharts": "^2.12.7"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
@@ -53,6 +54,9 @@
     "tw-animate-css": "^1.3.6",
     "typescript": "^5",
     "vitest": "^1.6.1",
-    "jsdom": "^24.0.0"
+    "jsdom": "^24.0.0",
+    "@types/recharts": "^1.8.25",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/jest-dom": "^6.4.0"
   }
 }


### PR DESCRIPTION
## Summary
- install recharts and testing libraries
- add useSkillRadarData hook for chart dataset
- create SkillsRadarChart component with filtering
- provide unit tests for hook and component

## Testing
- `npm run lint`
- `npm test` *(fails: Failed to resolve import "@testing-library/react")*

------
https://chatgpt.com/codex/tasks/task_e_68c80a7c6ad0832984735012a137cc7f