### PR TITLE
Display card counters on profile page

### DIFF
--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,10 +1,11 @@
-import Profile, { MyStory } from "@/components/profile";
+import Profile, { CardCounters, MyStory } from "@/components/profile";
 import OtherSkills from "@/components/profile/OtherSkills";
 
 export default function ProfilePage() {
   return (
     <main className="container mx-auto max-w-7xl px-4 py-12 space-y-16">
       <Profile />
+      <CardCounters />
       <MyStory />
       <section className="space-y-6">
         <h2 className="text-3xl font-bold tracking-tight text-teal-700 dark:text-teal-400">

--- a/components/profile/card-counters.test.tsx
+++ b/components/profile/card-counters.test.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { describe, it, expect } from "vitest";
+import { act } from "react-dom/test-utils";
+import { createRoot } from "react-dom/client";
+import CardCounters from "./card-counters";
+import data from "@/public/data/card-counter.json" assert { type: "json" };
+
+// Ensure React is available globally for components using the new JSX runtime
+(globalThis as { React?: typeof React }).React = React;
+
+describe("CardCounters", () => {
+  it("renders counters from data", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<CardCounters />);
+    });
+
+    data.items.forEach((item) => {
+      expect(container.textContent).toContain(item.title);
+      expect(container.textContent).toContain(item.value.toLocaleString());
+    });
+
+    root.unmount();
+    container.remove();
+  });
+});

--- a/components/profile/card-counters.tsx
+++ b/components/profile/card-counters.tsx
@@ -1,0 +1,44 @@
+import counterData from "@/public/data/card-counter.json" assert { type: "json" };
+import CounterCard, { type CounterCardTheme } from "@/components/card/CardCounter";
+
+interface CardCounterItem {
+  id: string;
+  title: string;
+  value: number;
+  description?: string;
+  theme?: CounterCardTheme;
+  order: number;
+}
+
+/**
+ * Renders a grid of {@link CounterCard} components based on data in
+ * `public/data/card-counter.json`.
+ *
+ * @example
+ * ```tsx
+ * import CardCounters from "@/components/profile/card-counters";
+ *
+ * export default function Example() {
+ *   return <CardCounters />;
+ * }
+ * ```
+ */
+export default function CardCounters(): JSX.Element {
+  const items: CardCounterItem[] = [...counterData.items].sort(
+    (a, b) => a.order - b.order
+  );
+
+  return (
+    <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      {items.map(({ id, title, value, description, theme }) => (
+        <CounterCard
+          key={id}
+          count={value}
+          title={title}
+          description={description}
+          theme={theme}
+        />
+      ))}
+    </section>
+  );
+}

--- a/components/profile/index.ts
+++ b/components/profile/index.ts
@@ -1,3 +1,4 @@
 export { default } from "./Profile";
 export { default as MyStory } from "./MyStory";
 export { default as AboutMe } from "./AboutMe";
+export { default as CardCounters } from "./card-counters";


### PR DESCRIPTION
## Summary
- add `CardCounters` component that renders stats from JSON
- show counter cards on profile page
- cover new component with unit test

## Testing
- `npm run lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68c81b42ea988329a5030463c8bb7310