### PR TITLE
feat: integrate tech comparison dashboard on profile

### DIFF
--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,4 +1,4 @@
-import Profile, { CardCounters, MyStory } from "@/components/profile";
+import Profile, { CardCounters, MyStory, TechComparison } from "@/components/profile";
 import OtherSkills from "@/components/profile/OtherSkills";
 
 export default function ProfilePage() {
@@ -13,6 +13,7 @@ export default function ProfilePage() {
         </h2>
         <OtherSkills />
       </section>
+      <TechComparison />
     </main>
   );
 }

--- a/components/profile/index.ts
+++ b/components/profile/index.ts
@@ -2,3 +2,4 @@ export { default } from "./Profile";
 export { default as MyStory } from "./MyStory";
 export { default as AboutMe } from "./AboutMe";
 export { default as CardCounters } from "./card-counters";
+export { default as TechComparison } from "./tech-comparison";

--- a/components/profile/tech-comparison.test.tsx
+++ b/components/profile/tech-comparison.test.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { act } from "react-dom/test-utils";
+import { createRoot } from "react-dom/client";
+import TechComparison from "./tech-comparison";
+import rawData from "@/public/data/tech-comparison.json" assert { type: "json" };
+import { type TechComparisonData } from "@/types/tech-comparison";
+
+(globalThis as { React?: typeof React }).React = React;
+
+vi.mock("@/components/tech-comparison", () => ({
+  __esModule: true,
+  TechComparisonDashboard: ({ data }: { data: TechComparisonData }) => (
+    <div>{data.lastUpdated}</div>
+  ),
+}));
+
+describe("TechComparison", () => {
+  it("renders dashboard with data", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const techData: TechComparisonData = rawData;
+
+    await act(async () => {
+      root.render(<TechComparison />);
+    });
+
+    expect(container.textContent).toContain(techData.lastUpdated ?? "");
+
+    root.unmount();
+    container.remove();
+  });
+});
+

--- a/components/profile/tech-comparison.tsx
+++ b/components/profile/tech-comparison.tsx
@@ -1,0 +1,20 @@
+import techComparisonData from "@/public/data/tech-comparison.json" assert { type: "json" };
+import { TechComparisonDashboard, type TechComparisonData } from "@/components/tech-comparison";
+
+/**
+ * Displays the {@link TechComparisonDashboard} using statically imported data.
+ *
+ * @example
+ * ```tsx
+ * import { TechComparison } from "@/components/profile";
+ *
+ * export default function Example() {
+ *   return <TechComparison />;
+ * }
+ * ```
+ */
+export default function TechComparison(): JSX.Element {
+  const data: TechComparisonData = techComparisonData;
+  return <TechComparisonDashboard data={data} />;
+}
+


### PR DESCRIPTION
## Summary
- add TechComparison wrapper component to load dashboard data
- show TechComparison on profile page

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c8270164fc8329aad0067938ab9361