### PR TITLE
Add card counter types and type JSON imports

### DIFF
--- a/components/profile/card-counters.test.tsx
+++ b/components/profile/card-counters.test.tsx
@@ -3,13 +3,15 @@ import { describe, it, expect } from "vitest";
 import { act } from "react-dom/test-utils";
 import { createRoot } from "react-dom/client";
 import CardCounters from "./card-counters";
-import data from "@/public/data/card-counter.json" assert { type: "json" };
+import rawData from "@/public/data/card-counter.json" assert { type: "json" };
+import { type CardCounterData } from "@/types/card-counter";
 
 // Ensure React is available globally for components using the new JSX runtime
 (globalThis as { React?: typeof React }).React = React;
 
 describe("CardCounters", () => {
   it("renders counters from data", async () => {
+    const data: CardCounterData = rawData;
     const container = document.createElement("div");
     document.body.appendChild(container);
     const root = createRoot(container);

--- a/components/profile/card-counters.tsx
+++ b/components/profile/card-counters.tsx
@@ -1,16 +1,8 @@
 import { type ReactElement } from "react";
 
-import counterData from "@/public/data/card-counter.json" assert { type: "json" };
-import CounterCard, { type CounterCardTheme } from "@/components/card/CardCounter";
-
-interface CardCounterItem {
-  id: string;
-  title: string;
-  value: number;
-  description?: string;
-  theme?: CounterCardTheme;
-  order: number;
-}
+import rawData from "@/public/data/card-counter.json" assert { type: "json" };
+import CounterCard from "@/components/card/CardCounter";
+import { type CardCounterData, type CardCounterItem } from "@/types/card-counter";
 
 /**
  * Renders a grid of {@link CounterCard} components based on data in
@@ -26,6 +18,7 @@ interface CardCounterItem {
  * ```
  */
 export default function CardCounters(): ReactElement {
+  const counterData: CardCounterData = rawData;
   const items: CardCounterItem[] = [...counterData.items].sort(
     (a, b) => a.order - b.order
   );

--- a/types/card-counter.ts
+++ b/types/card-counter.ts
@@ -1,0 +1,15 @@
+import { CounterCardTheme } from "@/components/card/CardCounter";
+
+export interface CardCounterItem {
+  id: string;
+  title: string;
+  value: number;
+  description?: string;
+  theme: CounterCardTheme;
+  order: number;
+}
+
+export interface CardCounterData {
+  lastUpdated: string;
+  items: CardCounterItem[];
+}


### PR DESCRIPTION
## Summary
- add shared card counter data interfaces under `types`
- update the card counters component to consume typed JSON data
- type the card counter profile test JSON fixture

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c835c714748329ba9a24b468978046