### PR TITLE
Validate card counter data before rendering

### DIFF
--- a/components/card/CardCounter.tsx
+++ b/components/card/CardCounter.tsx
@@ -8,8 +8,7 @@ import {
   CardContent,
 } from "@/components/ui/card";
 import { cn } from "@/lib/cn";
-
-export type CounterCardTheme = "ocean" | "teal" | "cyan" | "ice";
+import { type CounterCardTheme } from "@/types/card-counter";
 
 const THEME_STYLES: Record<
   CounterCardTheme,

--- a/components/profile/card-counters.test.tsx
+++ b/components/profile/card-counters.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect } from "vitest";
 import { act } from "react-dom/test-utils";
 import { createRoot } from "react-dom/client";
 import CardCounters from "./card-counters";
-import rawData from "@/public/data/card-counter.json" assert { type: "json" };
+import { getCardCounterData } from "@/lib/profile-card-counter-data";
 import { type CardCounterData } from "@/types/card-counter";
 
 // Ensure React is available globally for components using the new JSX runtime
@@ -11,7 +11,7 @@ import { type CardCounterData } from "@/types/card-counter";
 
 describe("CardCounters", () => {
   it("renders counters from data", async () => {
-    const data: CardCounterData = rawData;
+    const data: CardCounterData = getCardCounterData();
     const container = document.createElement("div");
     document.body.appendChild(container);
     const root = createRoot(container);

--- a/components/profile/card-counters.tsx
+++ b/components/profile/card-counters.tsx
@@ -1,7 +1,7 @@
 import { type ReactElement } from "react";
 
-import rawData from "@/public/data/card-counter.json" assert { type: "json" };
 import CounterCard from "@/components/card/CardCounter";
+import { getCardCounterData } from "@/lib/profile-card-counter-data";
 import { type CardCounterData, type CardCounterItem } from "@/types/card-counter";
 
 /**
@@ -18,7 +18,7 @@ import { type CardCounterData, type CardCounterItem } from "@/types/card-counter
  * ```
  */
 export default function CardCounters(): ReactElement {
-  const counterData: CardCounterData = rawData;
+  const counterData: CardCounterData = getCardCounterData();
   const items: CardCounterItem[] = [...counterData.items].sort(
     (a, b) => a.order - b.order
   );

--- a/lib/profile-card-counter-data.test.ts
+++ b/lib/profile-card-counter-data.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { parseCardCounterData } from "./profile-card-counter-data";
+
+describe("parseCardCounterData", () => {
+  it("returns typed card counter data when the shape is valid", () => {
+    const result = parseCardCounterData({
+      lastUpdated: "2025-01-01",
+      items: [
+        {
+          id: "example",
+          title: "Example",
+          value: 5,
+          description: "Example description",
+          theme: "ocean",
+          order: 1,
+          icon: "Sparkles",
+        },
+      ],
+    });
+
+    expect(result.lastUpdated).toBe("2025-01-01");
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]).toMatchObject({
+      id: "example",
+      title: "Example",
+      value: 5,
+      description: "Example description",
+      theme: "ocean",
+      order: 1,
+      icon: "Sparkles",
+    });
+  });
+
+  it("throws when a theme value is not supported", () => {
+    expect(() =>
+      parseCardCounterData({
+        lastUpdated: "2025-01-01",
+        items: [
+          {
+            id: "invalid-theme",
+            title: "Invalid",
+            value: 1,
+            theme: "magenta",
+            order: 1,
+          },
+        ],
+      })
+    ).toThrow(/theme/);
+  });
+});

--- a/lib/profile-card-counter-data.ts
+++ b/lib/profile-card-counter-data.ts
@@ -1,0 +1,115 @@
+import rawData from "@/public/data/card-counter.json" assert { type: "json" };
+import {
+  COUNTER_CARD_THEMES,
+  type CardCounterData,
+  type CardCounterItem,
+  type CounterCardTheme,
+} from "@/types/card-counter";
+
+const COUNTER_CARD_THEME_SET = new Set<string>(COUNTER_CARD_THEMES);
+
+type RawCardCounterItem = {
+  id?: unknown;
+  title?: unknown;
+  value?: unknown;
+  description?: unknown;
+  theme?: unknown;
+  order?: unknown;
+  icon?: unknown;
+};
+
+type RawCardCounterData = {
+  lastUpdated?: unknown;
+  items?: unknown;
+};
+
+const isCounterCardTheme = (value: unknown): value is CounterCardTheme =>
+  typeof value === "string" && COUNTER_CARD_THEME_SET.has(value);
+
+const parseCardCounterItem = (item: unknown, index: number): CardCounterItem => {
+  if (!item || typeof item !== "object") {
+    throw new Error(`Item at index ${index} must be an object.`);
+  }
+
+  const { id, title, value, description, theme, order, icon } =
+    item as RawCardCounterItem;
+
+  if (typeof id !== "string" || id.trim().length === 0) {
+    throw new Error(`Item at index ${index} is missing a valid \"id\".`);
+  }
+
+  if (typeof title !== "string" || title.trim().length === 0) {
+    throw new Error(`Item at index ${index} is missing a valid \"title\".`);
+  }
+
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    throw new Error(`Item at index ${index} is missing a valid \"value\".`);
+  }
+
+  if (typeof order !== "number" || !Number.isFinite(order)) {
+    throw new Error(`Item at index ${index} is missing a valid \"order\".`);
+  }
+
+  if (!isCounterCardTheme(theme)) {
+    throw new Error(
+      `Item at index ${index} has an unsupported theme: ${String(theme)}`
+    );
+  }
+
+  if (description != null && typeof description !== "string") {
+    throw new Error(
+      `Item at index ${index} has an invalid \"description\" field.`
+    );
+  }
+
+  const parsedItem: CardCounterItem = {
+    id,
+    title,
+    value,
+    order,
+    theme,
+  };
+
+  if (typeof description === "string") {
+    parsedItem.description = description;
+  }
+
+  if (typeof icon === "string" && icon.trim().length > 0) {
+    parsedItem.icon = icon;
+  }
+
+  return parsedItem;
+};
+
+/**
+ * Converts unknown JSON data into a strongly typed {@link CardCounterData} object.
+ *
+ * @throws Error when the input data structure is invalid.
+ */
+export const parseCardCounterData = (data: unknown): CardCounterData => {
+  if (!data || typeof data !== "object") {
+    throw new Error("Card counter data must be a JSON object.");
+  }
+
+  const { lastUpdated, items } = data as RawCardCounterData;
+
+  if (typeof lastUpdated !== "string" || lastUpdated.trim().length === 0) {
+    throw new Error("Card counter data requires a non-empty lastUpdated value.");
+  }
+
+  if (!Array.isArray(items)) {
+    throw new Error("Card counter data requires an items array.");
+  }
+
+  return {
+    lastUpdated,
+    items: items.map((item, index) => parseCardCounterItem(item, index)),
+  };
+};
+
+/**
+ * Returns the parsed {@link CardCounterData} sourced from
+ * `public/data/card-counter.json`.
+ */
+export const getCardCounterData = (): CardCounterData =>
+  parseCardCounterData(rawData as unknown);

--- a/types/card-counter.ts
+++ b/types/card-counter.ts
@@ -1,4 +1,6 @@
-import { CounterCardTheme } from "@/components/card/CardCounter";
+export const COUNTER_CARD_THEMES = ["ocean", "teal", "cyan", "ice"] as const;
+
+export type CounterCardTheme = (typeof COUNTER_CARD_THEMES)[number];
 
 export interface CardCounterItem {
   id: string;
@@ -7,6 +9,7 @@ export interface CardCounterItem {
   description?: string;
   theme: CounterCardTheme;
   order: number;
+  icon?: string;
 }
 
 export interface CardCounterData {


### PR DESCRIPTION
## Summary
- add a shared card counter theme definition and parse helper to validate the JSON payload
- update the card counters component and tests to consume the typed data
- cover the parser with unit tests to guard against unsupported themes

## Testing
- npm run lint
- npm test
- npm run build *(fails: Next.js cannot resolve `recharts`, see build output)*

------
https://chatgpt.com/codex/tasks/task_e_68c83743c94c832992ceca95391c665c