### PR TITLE
Use chart bar theme token for bar summary

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3,6 +3,14 @@
 @custom-variant dark (&:is(.dark *));
 
 @layer base {
+  :root {
+    --chart-bar: 199 89% 55%;
+  }
+
+  .dark {
+    --chart-bar: 199 94% 68%;
+  }
+
   * {
     @apply border-gray-200 dark:border-gray-700;
   }

--- a/components/tech-comparison/bar-summary.test.tsx
+++ b/components/tech-comparison/bar-summary.test.tsx
@@ -1,5 +1,72 @@
-import { describe, it } from "vitest";
+import React from "react";
+import type { PropsWithChildren } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { act } from "react-dom/test-utils";
+import { createRoot } from "react-dom/client";
+import type { TechItem } from "@/types/tech-comparison";
+import BarSummary, { CHART_BAR_FILL } from "./bar-summary";
+
+type ChartContainerProps = PropsWithChildren<Record<string, unknown>>;
+type BarStubProps = ChartContainerProps & { fill?: string };
+
+vi.mock("recharts", async () => {
+  const ReactModule = await import("react");
+
+  const Container = ({ children }: ChartContainerProps) =>
+    ReactModule.createElement("div", null, children);
+
+  const Static = () => ReactModule.createElement("div");
+
+  const BarStub = ({ fill }: BarStubProps) =>
+    ReactModule.createElement("div", { "data-testid": "chart-bar", "data-fill": fill });
+
+  return {
+    __esModule: true,
+    ResponsiveContainer: Container,
+    BarChart: Container,
+    CartesianGrid: Static,
+    XAxis: Static,
+    YAxis: Static,
+    Tooltip: Static,
+    Bar: BarStub,
+  };
+});
+
+(globalThis as { React?: typeof React }).React = React;
 
 describe("BarSummary", () => {
-  it.skip("requires recharts which is unavailable in test environment", () => {});
+  it("renders bars using the chart theme color", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    const items: TechItem[] = [
+      {
+        id: "react",
+        name: "React",
+        type: "library",
+        category: "frontend",
+        ratings: {
+          proficiency: 4,
+          production_use: 4,
+          recency: 5,
+          depth: 4,
+          preference: 5,
+        },
+      },
+    ];
+
+    await act(async () => {
+      root.render(<BarSummary items={items} rating="proficiency" label="Proficiency" />);
+    });
+
+    const bar = container.querySelector<HTMLElement>("[data-testid='chart-bar']");
+
+    expect(bar).not.toBeNull();
+    expect(CHART_BAR_FILL).toBe("hsl(var(--chart-bar))");
+    expect(bar?.getAttribute("data-fill")).toBe(CHART_BAR_FILL);
+
+    root.unmount();
+    container.remove();
+  });
 });

--- a/components/tech-comparison/bar-summary.tsx
+++ b/components/tech-comparison/bar-summary.tsx
@@ -16,6 +16,8 @@ export interface BarSummaryProps {
   label: string;
 }
 
+export const CHART_BAR_FILL = "hsl(var(--chart-bar))";
+
 export function BarSummary({ items, rating }: BarSummaryProps): React.ReactElement {
   const data = items
     .map((it) => ({ name: it.name, value: it.ratings[rating] ?? 0 }))
@@ -30,7 +32,7 @@ export function BarSummary({ items, rating }: BarSummaryProps): React.ReactEleme
           <XAxis dataKey="name" tick={{ fontSize: 12 }} interval={0} angle={-30} textAnchor="end" height={60} />
           <YAxis domain={[0, 5]} tickCount={6} />
           <ReTooltip />
-          <Bar dataKey="value" fill="#0ea5e9" radius={[6, 6, 0, 0]} />
+          <Bar dataKey="value" fill={CHART_BAR_FILL} radius={[6, 6, 0, 0]} />
         </BarChart>
       </ResponsiveContainer>
     </div>


### PR DESCRIPTION
## Summary
- add a `--chart-bar` design token with light and dark variants
- update the bar summary chart to consume the theme-aware bar color
- add a regression test confirming the bar uses the theme token fill

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c83cd22b788329abf122839f9b3149