### PR TITLE
Refactor tech comparison dashboard to use hook

### DIFF
--- a/components/tech-comparison/tech-comparison-dashboard.tsx
+++ b/components/tech-comparison/tech-comparison-dashboard.tsx
@@ -10,7 +10,8 @@ import CategoryTabs from "./category-tabs";
 import ItemList from "./item-list";
 import RadarView from "./radar-view";
 import BarSummary from "./bar-summary";
-import { TechComparisonData, RatingTypesId } from "@/types/tech-comparison";
+import { useTechComparison } from "@/hooks/use-tech-comparison";
+import { TechComparisonData } from "@/types/tech-comparison";
 
 export interface TechComparisonDashboardProps {
   data: TechComparisonData;
@@ -19,27 +20,15 @@ export interface TechComparisonDashboardProps {
 export function TechComparisonDashboard({ data }: TechComparisonDashboardProps): React.ReactElement {
   const ratingTypes = data.rating_types;
   const categories = data.categories;
-  const [selectedRating, setSelectedRating] = React.useState<RatingTypesId>(
-    ratingTypes[0]?.id ?? "proficiency"
-  );
-  const [selectedCategory, setSelectedCategory] = React.useState<string>("all");
-
-  const categoriesById = React.useMemo(
-    () => Object.fromEntries(categories.map((c) => [c.id, c])),
-    [categories]
-  );
-
-  const filtered = React.useMemo(() => {
-    const pool =
-      selectedCategory === "all"
-        ? data.items
-        : data.items.filter((i) => i.category === selectedCategory);
-    return [...pool].sort(
-      (a, b) => (b.ratings[selectedRating] ?? 0) - (a.ratings[selectedRating] ?? 0)
-    );
-  }, [data.items, selectedCategory, selectedRating]);
-
-  const topItem = filtered[0] ?? data.items[0];
+  const {
+    selectedRating,
+    setSelectedRating,
+    selectedCategory,
+    setSelectedCategory,
+    filteredItems,
+    topItem,
+    categoriesById,
+  } = useTechComparison(data);
   const selectedRatingLabel =
     ratingTypes.find((r) => r.id === selectedRating)?.label ?? selectedRating;
 
@@ -81,7 +70,7 @@ export function TechComparisonDashboard({ data }: TechComparisonDashboardProps):
             </CardHeader>
             <CardContent>
               <BarSummary
-                items={filtered}
+                items={filteredItems}
                 rating={selectedRating}
                 label={selectedRatingLabel}
               />
@@ -109,7 +98,7 @@ export function TechComparisonDashboard({ data }: TechComparisonDashboardProps):
             </span>
           </div>
           <ItemList
-            items={filtered}
+            items={filteredItems}
             selectedRating={selectedRating}
             categoriesById={categoriesById}
           />

--- a/hooks/use-tech-comparison.test.tsx
+++ b/hooks/use-tech-comparison.test.tsx
@@ -1,0 +1,164 @@
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { act } from "react-dom/test-utils";
+import { createRoot } from "react-dom/client";
+import { useTechComparison, type UseTechComparisonResult } from "./use-tech-comparison";
+import type { TechComparisonData } from "@/types/tech-comparison";
+
+interface HookTestProps {
+  data: TechComparisonData;
+  onRender: (value: UseTechComparisonResult) => void;
+}
+
+function HookTestComponent({ data, onRender }: HookTestProps): React.ReactElement | null {
+  const values = useTechComparison(data);
+
+  React.useEffect(() => {
+    onRender(values);
+  }, [values, onRender]);
+
+  return null;
+}
+
+(globalThis as { React?: typeof React }).React = React;
+
+function createTestData(): TechComparisonData {
+  return {
+    lastUpdated: "2024-01-01",
+    rating_types: [
+      { id: "proficiency", label: "Proficiency", description: "", scale: {} },
+      { id: "recency", label: "Recency", description: "", scale: {} },
+    ],
+    categories: [
+      { id: "frontend", label: "Frontend" },
+      { id: "backend", label: "Backend" },
+      { id: "ops", label: "Operations" },
+    ],
+    items: [
+      {
+        id: "1",
+        name: "React",
+        type: "Library",
+        category: "frontend",
+        ratings: {
+          proficiency: 5,
+          production_use: 4,
+          recency: 3,
+          depth: 4,
+          preference: 5,
+        },
+      },
+      {
+        id: "2",
+        name: "Node.js",
+        type: "Runtime",
+        category: "backend",
+        ratings: {
+          proficiency: 4,
+          production_use: 5,
+          recency: 4,
+          depth: 3,
+          preference: 4,
+        },
+      },
+      {
+        id: "3",
+        name: "Astro",
+        type: "Framework",
+        category: "frontend",
+        ratings: {
+          proficiency: 3,
+          production_use: 2,
+          recency: 5,
+          depth: 2,
+          preference: 3,
+        },
+      },
+    ],
+  };
+}
+
+describe("useTechComparison", () => {
+  it("updates filtered items when rating changes", async () => {
+    const data = createTestData();
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    let latest: UseTechComparisonResult | undefined;
+    const handleRender = (value: UseTechComparisonResult): void => {
+      latest = value;
+    };
+
+    await act(async () => {
+      root.render(<HookTestComponent data={data} onRender={handleRender} />);
+    });
+
+    expect(latest?.selectedRating).toBe("proficiency");
+    expect(latest?.filteredItems.map((item) => item.id)).toEqual(["1", "2", "3"]);
+
+    await act(async () => {
+      latest?.setSelectedRating("recency");
+    });
+
+    expect(latest?.selectedRating).toBe("recency");
+    expect(latest?.filteredItems.map((item) => item.id)).toEqual(["3", "2", "1"]);
+
+    root.unmount();
+    container.remove();
+  });
+
+  it("filters items by category and exposes a category map", async () => {
+    const data = createTestData();
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    let latest: UseTechComparisonResult | undefined;
+    const handleRender = (value: UseTechComparisonResult): void => {
+      latest = value;
+    };
+
+    await act(async () => {
+      root.render(<HookTestComponent data={data} onRender={handleRender} />);
+    });
+
+    await act(async () => {
+      latest?.setSelectedCategory("backend");
+    });
+
+    expect(latest?.selectedCategory).toBe("backend");
+    expect(latest?.filteredItems).toHaveLength(1);
+    expect(latest?.filteredItems[0]?.id).toBe("2");
+    expect(latest?.categoriesById.backend?.label).toBe("Backend");
+
+    root.unmount();
+    container.remove();
+  });
+
+  it("falls back to the first item when a category has no matches", async () => {
+    const data = createTestData();
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    let latest: UseTechComparisonResult | undefined;
+    const handleRender = (value: UseTechComparisonResult): void => {
+      latest = value;
+    };
+
+    await act(async () => {
+      root.render(<HookTestComponent data={data} onRender={handleRender} />);
+    });
+
+    await act(async () => {
+      latest?.setSelectedCategory("ops");
+    });
+
+    expect(latest?.filteredItems).toHaveLength(0);
+    expect(latest?.topItem?.id).toBe("1");
+
+    root.unmount();
+    container.remove();
+  });
+});

--- a/hooks/use-tech-comparison.ts
+++ b/hooks/use-tech-comparison.ts
@@ -1,0 +1,67 @@
+"use client";
+
+import React from "react";
+import type {
+  Category,
+  RatingTypesId,
+  TechComparisonData,
+  TechItem,
+} from "@/types/tech-comparison";
+
+export interface UseTechComparisonResult {
+  selectedRating: RatingTypesId;
+  setSelectedRating: React.Dispatch<React.SetStateAction<RatingTypesId>>;
+  selectedCategory: string;
+  setSelectedCategory: React.Dispatch<React.SetStateAction<string>>;
+  filteredItems: TechItem[];
+  topItem: TechItem | undefined;
+  categoriesById: Record<string, Category>;
+}
+
+/**
+ * Provides memoized selection and filtering helpers for the tech comparison dashboard.
+ *
+ * @example
+ * ```tsx
+ * const { filteredItems } = useTechComparison(data);
+ * ```
+ */
+export function useTechComparison(data: TechComparisonData): UseTechComparisonResult {
+  const ratingTypes = data.rating_types;
+  const categories = data.categories;
+
+  const [selectedRating, setSelectedRating] = React.useState<RatingTypesId>(
+    ratingTypes[0]?.id ?? "proficiency"
+  );
+  const [selectedCategory, setSelectedCategory] = React.useState<string>("all");
+
+  const categoriesById = React.useMemo<Record<string, Category>>(
+    () => Object.fromEntries(categories.map((category) => [category.id, category])),
+    [categories]
+  );
+
+  const filteredItems = React.useMemo<TechItem[]>(() => {
+    const pool =
+      selectedCategory === "all"
+        ? data.items
+        : data.items.filter((item) => item.category === selectedCategory);
+
+    return [...pool].sort(
+      (a, b) => (b.ratings[selectedRating] ?? 0) - (a.ratings[selectedRating] ?? 0)
+    );
+  }, [data.items, selectedCategory, selectedRating]);
+
+  const topItem = filteredItems[0] ?? data.items[0];
+
+  return {
+    selectedRating,
+    setSelectedRating,
+    selectedCategory,
+    setSelectedCategory,
+    filteredItems,
+    topItem,
+    categoriesById,
+  };
+}
+
+export default useTechComparison;


### PR DESCRIPTION
## Summary
- extract the tech comparison selection and filtering logic into a dedicated `useTechComparison` hook
- update the dashboard component to consume the hook so it stays presentational
- add unit coverage for the hook across rating changes, category filters, and empty category fallbacks

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c83ccc3ee48329a5defd7000860c2d