### PR TITLE
Add ReactElement return types to default components

### DIFF
--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,4 +1,4 @@
-import Profile, { CardCounters, MyStory, TechComparison } from "@/components/profile";
+import Profile, { MyStory, TechComparison } from "@/components/profile";
 import OtherSkills from "@/components/profile/OtherSkills";
 
 export default function ProfilePage() {

--- a/components/awards/Awards.tsx
+++ b/components/awards/Awards.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React from "react";
+import { type ReactElement } from "react";
 import { motion, type Variants, type Transition } from "framer-motion";
 import { Card, CardContent } from "@/components/ui/card";
 import { useData } from "@/lib/use-data";
@@ -23,7 +24,7 @@ const itemVariants: Variants = {
   },
 };
 
-export default function Awards() {
+export default function Awards(): ReactElement {
   const { data, loading, error } = useData<Achievement[]>("achievements.json");
 
   if (loading) return <p className="text-black dark:text-white">Loading awards...</p>;

--- a/components/banner.tsx
+++ b/components/banner.tsx
@@ -3,14 +3,14 @@
 
 import { cn, withBasePath } from "@/lib/utils";
 import Image from "next/image";
-import * as React from "react";
+import { type ReactElement, type ReactNode } from "react";
 
 type Align = "left" | "center" | "right";
 type Height = "sm" | "md" | "lg" | "screen";
 
 export interface BannerProps {
-  title: React.ReactNode;
-  subtitle?: React.ReactNode;
+  title: ReactNode;
+  subtitle?: ReactNode;
   /** Absolute or public path (e.g., /static/hero.jpg) */
   backgroundImage: string;
   /** Improves accessibility; describe the image context briefly */
@@ -26,7 +26,7 @@ export interface BannerProps {
   /** Additional className for the root section */
   className?: string;
   /** Optional action buttons or extra content under subtitle */
-  actions?: React.ReactNode;
+  actions?: ReactNode;
   /** Control background object position (e.g., "50% 30%" or "center top") */
   objectPosition?: string;
   /** Prioritize image loading (good for above-the-fold heroes) */
@@ -53,7 +53,7 @@ export default function Banner({
   actions,
   objectPosition = "center",
   priority = false,
-}: BannerProps) {
+}: BannerProps): ReactElement {
   const alignWrap =
     align === "left"
       ? "ml-0 mr-auto text-left"

--- a/components/card/CardCounter.tsx
+++ b/components/card/CardCounter.tsx
@@ -1,5 +1,5 @@
 // components/counter-card.tsx
-import * as React from "react";
+import { type ReactElement } from "react";
 import {
   Card,
   CardHeader,
@@ -71,7 +71,7 @@ export default function CounterCard({
   className,
   theme = "ocean",
   dotClassName,
-}: CounterCardProps) {
+}: CounterCardProps): ReactElement {
   const formatted =
     typeof count === "number" ? count.toLocaleString() : String(count);
 

--- a/components/certificates/Certificates.tsx
+++ b/components/certificates/Certificates.tsx
@@ -1,6 +1,8 @@
+import { type ReactElement } from "react";
+
 import CertificatesSection from "./certificates-section";
 
-export default function Certificates() {
+export default function Certificates(): ReactElement {
   return (
     <section className="space-y-4">
       <h1 className="text-3xl font-bold tracking-tight text-teal-700 dark:text-teal-400">

--- a/components/certificates/certificates-section.tsx
+++ b/components/certificates/certificates-section.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { AnimatePresence, motion } from "framer-motion";
-import { useMemo, useState } from "react";
+import { useMemo, useState, type ReactElement } from "react";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
@@ -33,7 +33,7 @@ interface Certificate {
 
 const MAX_BADGES = 6;
 
-export default function CertificatesSection() {
+export default function CertificatesSection(): ReactElement {
   const [search, setSearch] = useState("");
   const [tag, setTag] = useState("");
 

--- a/components/courses/Courses.tsx
+++ b/components/courses/Courses.tsx
@@ -1,6 +1,8 @@
+import { type ReactElement } from "react";
+
 import CoursesSection from "./courses-section";
 
-export default function Courses() {
+export default function Courses(): ReactElement {
   return (
     <section className="space-y-4">
       <h1 className="text-3xl font-bold tracking-tight text-teal-700 dark:text-teal-400">Courses</h1>

--- a/components/courses/courses-section.tsx
+++ b/components/courses/courses-section.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { AnimatePresence, motion } from "framer-motion";
-import { useMemo, useState } from "react";
+import { useMemo, useState, type ReactElement } from "react";
 import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import {
@@ -28,7 +28,7 @@ interface Course {
   credits?: number;
 }
 
-export default function CoursesSection() {
+export default function CoursesSection(): ReactElement {
   const [search, setSearch] = useState("");
   const [institution, setInstitution] = useState("");
 

--- a/components/highlights.tsx
+++ b/components/highlights.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+import { type ReactElement } from "react";
 import Image from "next/image";
 import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious } from "@/components/ui/carousel";
 import { AspectRatio } from "@/components/ui/aspect-ratio";
@@ -11,7 +12,7 @@ interface HighlightItem {
   label: string;
 }
 
-export default function Highlights() {
+export default function Highlights(): ReactElement {
   const [highlights, setHighlights] = React.useState<HighlightItem[]>([]);
 
   React.useEffect(() => {

--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -1,3 +1,4 @@
+import { type ReactElement } from "react";
 import Link from "next/link";
 import { Github, Linkedin, Twitter } from "lucide-react";
 
@@ -28,7 +29,7 @@ const SOCIAL_LINKS = [
   },
 ] as const;
 
-export default function Footer() {
+export default function Footer(): ReactElement {
   return (
     <footer className="relative overflow-hidden border-t bg-gradient-to-r from-teal-600/20 to-transparent dark:from-teal-400/20 dark:to-transparent bg-size-200 animate-gradient-x">
       <span className="pointer-events-none absolute inset-0 dot-pattern opacity-30 blur-sm animate-dots" />

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+import { type ReactElement } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { motion } from "framer-motion";
@@ -54,7 +55,7 @@ const SOCIAL_LINKS = [
   },
 ] as const;
 
-export default function Header() {
+export default function Header(): ReactElement {
   const pathname = usePathname();
   const [hovered, setHovered] = React.useState<string | null>(null);
 

--- a/components/profile/AboutMe.tsx
+++ b/components/profile/AboutMe.tsx
@@ -1,4 +1,6 @@
-export default function AboutMe() {
+import { type ReactElement } from "react";
+
+export default function AboutMe(): ReactElement {
   return (
     <section className="space-y-4">
       <h1 className="text-3xl font-bold tracking-tight text-teal-700 dark:text-teal-400">About Me</h1>

--- a/components/profile/BackgroundCard.tsx
+++ b/components/profile/BackgroundCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+import { type ReactElement } from "react";
 import Autoplay from "embla-carousel-autoplay";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -17,7 +18,7 @@ import type { ProfileData } from "./types";
 import Image from "next/image";
 import { withBasePath } from "@/lib/utils";
 
-export default function BackgroundCard({ profile }: { profile: ProfileData }) {
+export default function BackgroundCard({ profile }: { profile: ProfileData }): ReactElement {
   const autoplay = React.useRef(
     Autoplay({ delay: 4500, stopOnInteraction: true })
   );

--- a/components/profile/MyStory.tsx
+++ b/components/profile/MyStory.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { type ReactElement } from "react";
 import {
   Code2,
   Database,
@@ -17,7 +18,7 @@ import { Badge } from "@/components/ui/badge";
 import { Sparkles, Rocket } from "lucide-react";
 import ServicesSection from "@/components/services";
 
-export default function MyStory() {
+export default function MyStory(): ReactElement {
   const whatIDo = [
     {
       icon: <Code2 className="h-5 w-5" />,

--- a/components/profile/OtherSkills.tsx
+++ b/components/profile/OtherSkills.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { type ReactElement } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { useData } from "@/lib/use-data";
@@ -20,9 +21,9 @@ interface SkillCategory {
   groups: SkillGroup[];
 }
 
-export default function OtherSkills() {
+export default function OtherSkills(): ReactElement {
   const { data, error } = useData<SkillCategory[]>("skills.json");
-  if (error || !data) return null;
+  if (error || !data) return <></>;
 
   const otherCategories = data.filter(
     (category) => category.id !== "Programming"

--- a/components/profile/Profile.tsx
+++ b/components/profile/Profile.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { type ReactElement } from "react";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import ProfileCard from "./ProfileCard";
 import BackgroundCard from "./BackgroundCard";
@@ -31,7 +32,7 @@ const PROFILE: ProfileData = {
   },
 };
 
-export default function Profile() {
+export default function Profile(): ReactElement {
   return (
     <TooltipProvider delayDuration={100}>
       <section id="profile" className="space-y-6">

--- a/components/profile/ProfileCard.tsx
+++ b/components/profile/ProfileCard.tsx
@@ -1,12 +1,13 @@
 "use client";
 
+import { type ReactElement } from "react";
 import type { ProfileData } from "./types";
 import ProfileCardSkeleton from "./ProfileCardSkeleton";
 import ProfileCardContent from "./ProfileCardContent";
 
 type Props = { profile?: ProfileData | null };
 
-export default function ProfileCard({ profile }: Props) {
+export default function ProfileCard({ profile }: Props): ReactElement {
   if (!profile) {
     return <ProfileCardSkeleton />;
   }

--- a/components/profile/ProfileCardContent.tsx
+++ b/components/profile/ProfileCardContent.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { type ReactElement } from "react";
 import { motion } from "framer-motion";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
@@ -53,7 +54,7 @@ const socialList: { key: keyof Links; label: string; icon: LucideIcon }[] = [
   { key: "resume", label: "Resume", icon: FileText },
 ];
 
-export default function ProfileCardContent({ profile }: { profile: ProfileData }) {
+export default function ProfileCardContent({ profile }: { profile: ProfileData }): ReactElement {
   const links = profile.links ?? {};
 
   const info = profile as Partial<{

--- a/components/profile/ProfileCardSkeleton.tsx
+++ b/components/profile/ProfileCardSkeleton.tsx
@@ -1,10 +1,11 @@
 "use client";
 
+import { type ReactElement } from "react";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 
-export default function ProfileCardSkeleton() {
+export default function ProfileCardSkeleton(): ReactElement {
   return (
     <Card className="relative overflow-hidden">
       <div

--- a/components/profile/SocialIcon.tsx
+++ b/components/profile/SocialIcon.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { type ReactElement, type ReactNode } from "react";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 
 export default function SocialIcon({
@@ -9,9 +10,9 @@ export default function SocialIcon({
 }: {
   href?: string;
   label: string;
-  children: React.ReactNode;
-}) {
-  if (!href) return null;
+  children: ReactNode;
+}): ReactElement {
+  if (!href) return <></>;
   return (
     <Tooltip>
       <TooltipTrigger asChild>

--- a/components/profile/SocialLinks.tsx
+++ b/components/profile/SocialLinks.tsx
@@ -1,10 +1,11 @@
 "use client";
 
+import { type ReactElement } from "react";
 import { Facebook, Twitter, Linkedin, Github, FileText, Code } from "lucide-react";
 import SocialIcon from "./SocialIcon";
 import type { Links } from "./types";
 
-export default function SocialLinks({ links }: { links: Links }) {
+export default function SocialLinks({ links }: { links: Links }): ReactElement {
   return (
     <div className="flex flex-wrap items-center justify-center gap-3">
       <SocialIcon href={links.facebook} label="Facebook">

--- a/components/profile/StorySkills.tsx
+++ b/components/profile/StorySkills.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { type ReactElement } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { useData } from "@/lib/use-data";
@@ -20,12 +21,12 @@ interface SkillCategory {
   groups: SkillGroup[];
 }
 
-export default function StorySkills() {
+export default function StorySkills(): ReactElement {
   const { data, error } = useData<SkillCategory[]>("skills.json");
-  if (error || !data) return null;
+  if (error || !data) return <></>;
 
   const programming = data.find((category) => category.id === "Programming");
-  if (!programming) return null;
+  if (!programming) return <></>;
 
   return (
     <Card className="border border-teal-600/10 dark:border-teal-400/10">

--- a/components/project-details/ProjectGallery.tsx
+++ b/components/project-details/ProjectGallery.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+import { type ReactElement } from "react";
 import Image from "next/image";
 import { motion, AnimatePresence } from "framer-motion";
 import { X, ChevronLeft, ChevronRight, ZoomIn, ZoomOut, RotateCcw } from "lucide-react";
@@ -27,7 +28,7 @@ export default function ProjectGallery({
   showThumbnails = true,
   className,
   enableLightbox = true,
-}: ProjectGalleryProps) {
+}: ProjectGalleryProps): ReactElement {
   const [api, setApi] = React.useState<CarouselApi | null>(null);
   const [index, setIndex] = React.useState(0);
   const [count, setCount] = React.useState(0);

--- a/components/project-details/ProjectOverview.tsx
+++ b/components/project-details/ProjectOverview.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
 import Link from "next/link";
-import { ReactNode } from "react";
+import { type ReactElement, type ReactNode } from "react";
 import { withBasePath } from "@/lib/utils";
 import ProjectGallery from "./ProjectGallery";
 import { Button } from "@/components/ui/button";
@@ -22,7 +22,7 @@ export default function ProjectOverview({
   githubUrl,
   linkLabel = "View on GitHub",
   downloadUrl,
-}: ProjectOverviewProps) {
+}: ProjectOverviewProps): ReactElement {
   const firstImage = images[0];
 
   return (

--- a/components/project-details/ProjectSection.tsx
+++ b/components/project-details/ProjectSection.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import { type ReactElement, type ReactNode } from "react";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 
 interface ProjectSectionProps {
@@ -6,7 +6,7 @@ interface ProjectSectionProps {
   children: ReactNode;
 }
 
-export default function ProjectSection({ title, children }: ProjectSectionProps) {
+export default function ProjectSection({ title, children }: ProjectSectionProps): ReactElement {
   return (
     <Card className="relative overflow-hidden">
       <div

--- a/components/projects/Projects.tsx
+++ b/components/projects/Projects.tsx
@@ -1,6 +1,8 @@
+import { type ReactElement } from "react";
+
 import ProjectsSection from "./projects-section";
 
-export default function Projects() {
+export default function Projects(): ReactElement {
   return (
     <section className="space-y-4">
       <h1 className="text-3xl font-bold tracking-tight">Projects</h1>

--- a/components/projects/projects-section.tsx
+++ b/components/projects/projects-section.tsx
@@ -8,7 +8,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { useData } from "@/lib/use-data";
 import { withBasePath } from "@/lib/utils";
-import { useState } from "react";
+import { useState, type ReactElement } from "react";
 
 interface Project {
   title: string;
@@ -21,7 +21,7 @@ interface Project {
   details?: string | null;
 }
 
-export default function ProjectsSection() {
+export default function ProjectsSection(): ReactElement {
   const { data, loading, error } = useData<Project[]>("projects.json");
   const [expanded, setExpanded] = useState<Record<number, boolean>>({});
 

--- a/components/projects/tag-filter.tsx
+++ b/components/projects/tag-filter.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { type ReactElement } from "react";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 
@@ -15,7 +16,7 @@ export default function TagFilter({
   selected,
   onChange,
   className,
-}: TagFilterProps) {
+}: TagFilterProps): ReactElement {
   const toggleTag = (tag: string) => {
     onChange(
       selected.includes(tag)

--- a/components/services/ServicesSection.tsx
+++ b/components/services/ServicesSection.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { type ReactElement } from "react";
 import { useData } from "@/lib/use-data";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import * as Icons from "lucide-react";
@@ -11,7 +12,7 @@ interface Service {
   icon: keyof typeof Icons;
 }
 
-export default function ServicesSection() {
+export default function ServicesSection(): ReactElement {
   const { data, loading, error } = useData<Service[]>("services.json");
 
   if (loading)

--- a/components/work-experiences/WorkExperienceCarousel.tsx
+++ b/components/work-experiences/WorkExperienceCarousel.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { type ReactElement } from "react";
 import Image from "next/image";
 import { withBasePath } from "@/lib/utils";
 import { useData } from "@/lib/use-data";
@@ -20,7 +21,7 @@ interface WorkExperience {
   summary: string;
 }
 
-export default function WorkExperienceCarousel() {
+export default function WorkExperienceCarousel(): ReactElement {
   const { data, loading, error } = useData<WorkExperience[]>("work-experiences.json");
 
   if (loading) {

--- a/components/work-experiences/WorkExperiences.tsx
+++ b/components/work-experiences/WorkExperiences.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { type ReactElement } from "react";
 import { useData } from "@/lib/use-data";
 import { motion, type Variants } from "framer-motion";
 import Image from "next/image";
@@ -49,7 +50,7 @@ const listItem = {
   show: { opacity: 1, x: 0, transition: { duration: 0.25 } },
 } satisfies Variants;
 
-export default function WorkExperiences() {
+export default function WorkExperiences(): ReactElement {
   const { data, loading, error } = useData<WorkExperience[]>("work-experiences.json");
 
   if (loading) {


### PR DESCRIPTION
## Summary
- add explicit `ReactElement` return annotations to default component exports and import the type where required
- adjust components with null early returns to render fragments so the new return type remains valid
- update the banner props typings and drop the unused `CardCounters` import on the profile page to keep lint clean

## Testing
- npm run lint
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68c8a92477148329875ef22dd168b368