### PR TITLE
feat: enhance tech comparison visuals

### DIFF
--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,4 +1,4 @@
-import Profile, { CardCounters, MyStory, TechComparison } from "@/components/profile";
+import Profile, { MyStory, TechComparison } from "@/components/profile";
 import OtherSkills from "@/components/profile/OtherSkills";
 
 export default function ProfilePage() {

--- a/components/tech-comparison/category-tabs.test.tsx
+++ b/components/tech-comparison/category-tabs.test.tsx
@@ -6,9 +6,21 @@ import CategoryTabs from "./category-tabs";
 import { Category } from "@/types/tech-comparison";
 
 vi.mock("@/components/ui/tabs", () => ({
-  Tabs: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  TabsList: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  TabsTrigger: ({ children }: { children: React.ReactNode }) => <button>{children}</button>,
+  Tabs: ({ children, ...props }: { children: React.ReactNode }) => (
+    <div data-component="tabs" {...props}>
+      {children}
+    </div>
+  ),
+  TabsList: ({ children, ...props }: { children: React.ReactNode } & React.HTMLAttributes<HTMLDivElement>) => (
+    <div data-component="tabs-list" {...props}>
+      {children}
+    </div>
+  ),
+  TabsTrigger: ({ children, ...props }: { children: React.ReactNode } & React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button data-component="tabs-trigger" {...props}>
+      {children}
+    </button>
+  ),
 }));
 
 (globalThis as { React?: typeof React }).React = React;
@@ -28,6 +40,35 @@ describe("CategoryTabs", () => {
     });
 
     expect(container.textContent).toContain("Web");
+
+    root.unmount();
+    container.remove();
+  });
+
+  it("applies overflow handling classes", async () => {
+    const categories: Category[] = [
+      { id: "web", label: "Web" },
+      { id: "mobile", label: "Mobile" },
+    ];
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <CategoryTabs categories={categories} value="all" onValueChange={() => {}} />
+      );
+    });
+
+    const list = container.querySelector<HTMLDivElement>("[data-component='tabs-list']");
+    const triggers = container.querySelectorAll<HTMLButtonElement>("[data-component='tabs-trigger']");
+
+    expect(list?.className).toContain("overflow-x-auto");
+    expect(list?.getAttribute("aria-label")).toBe("Technology categories");
+    triggers.forEach((trigger) => {
+      expect(trigger.className).toContain("flex-none");
+    });
 
     root.unmount();
     container.remove();

--- a/components/tech-comparison/category-tabs.tsx
+++ b/components/tech-comparison/category-tabs.tsx
@@ -11,10 +11,19 @@ export interface CategoryTabsProps {
 export function CategoryTabs({ categories, value, onValueChange }: CategoryTabsProps): React.ReactElement {
   return (
     <Tabs value={value} onValueChange={onValueChange} className="w-full">
-      <TabsList className="grid w-full grid-cols-4 sm:grid-cols-6 lg:grid-cols-8">
-        <TabsTrigger value="all">All</TabsTrigger>
+      <TabsList
+        aria-label="Technology categories"
+        className="flex w-full flex-nowrap gap-2 overflow-x-auto pb-1"
+      >
+        <TabsTrigger value="all" className="flex-none whitespace-nowrap px-3">
+          All
+        </TabsTrigger>
         {categories.map((c) => (
-          <TabsTrigger key={c.id} value={c.id}>
+          <TabsTrigger
+            key={c.id}
+            value={c.id}
+            className="flex-none whitespace-nowrap px-3"
+          >
             {c.label}
           </TabsTrigger>
         ))}

--- a/components/tech-comparison/radar-view.test.tsx
+++ b/components/tech-comparison/radar-view.test.tsx
@@ -1,5 +1,126 @@
-import { describe, it } from "vitest";
+import React from "react";
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { act } from "react-dom/test-utils";
+import { createRoot } from "react-dom/client";
+import { RadarView, buildRadarChartData } from "./radar-view";
+import type { RatingType, TechItem } from "@/types/tech-comparison";
+
+const radarProps: Array<{ dataKey?: string }> = [];
+
+vi.mock("recharts", () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="responsive">{children}</div>
+  ),
+  RadarChart: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="radar-chart">{children}</div>
+  ),
+  PolarGrid: ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="polar-grid">{children}</div>
+  ),
+  PolarAngleAxis: () => <div data-testid="polar-angle-axis" />,
+  PolarRadiusAxis: () => <div data-testid="polar-radius-axis" />,
+  Legend: () => <div data-testid="legend" />,
+  Tooltip: () => <div data-testid="tooltip" />,
+  Radar: ({ dataKey }: { dataKey?: string }) => {
+    radarProps.push({ dataKey });
+    return <div data-testid="radar-series" data-key={dataKey} />;
+  },
+}));
+
+(globalThis as { React?: typeof React }).React = React;
+
+const ratingTypes: RatingType[] = [
+  { id: "proficiency", label: "Proficiency", description: "", scale: {} },
+  { id: "recency", label: "Recency", description: "", scale: {} },
+];
+
+const items: TechItem[] = [
+  {
+    id: "alpha",
+    name: "Alpha",
+    type: "Library",
+    category: "frontend",
+    ratings: {
+      proficiency: 5,
+      recency: 3,
+      production_use: 0,
+      depth: 0,
+      preference: 0,
+    },
+  },
+  {
+    id: "beta",
+    name: "Beta",
+    type: "Library",
+    category: "frontend",
+    ratings: {
+      proficiency: 4,
+      recency: 4,
+      production_use: 0,
+      depth: 0,
+      preference: 0,
+    },
+  },
+  {
+    id: "gamma",
+    name: "Gamma",
+    type: "Library",
+    category: "frontend",
+    ratings: {
+      proficiency: 2,
+      recency: 5,
+      production_use: 0,
+      depth: 0,
+      preference: 0,
+    },
+  },
+];
 
 describe("RadarView", () => {
-  it.skip("requires recharts which is unavailable in test environment", () => {});
+  beforeEach(() => {
+    radarProps.length = 0;
+  });
+
+  it("builds radar data points for every item", () => {
+    const data = buildRadarChartData(items, ratingTypes);
+
+    expect(data).toHaveLength(ratingTypes.length);
+    data.forEach((point) => {
+      expect(point.metric).toBeDefined();
+      expect(point.alpha).toBeTypeOf("number");
+      expect(point.beta).toBeTypeOf("number");
+      expect(point.gamma).toBeTypeOf("number");
+    });
+  });
+
+  it("limits the rendered radar series", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<RadarView items={items} ratingTypes={ratingTypes} maxSeries={2} />);
+    });
+
+    expect(radarProps).toHaveLength(2);
+    expect(radarProps.map((props) => props.dataKey)).toEqual(["alpha", "beta"]);
+
+    root.unmount();
+    container.remove();
+  });
+
+  it("renders a fallback when no items are provided", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<RadarView items={[]} ratingTypes={ratingTypes} />);
+    });
+
+    expect(container.textContent).toContain("No comparison data available");
+
+    root.unmount();
+    container.remove();
+  });
 });

--- a/components/tech-comparison/radar-view.tsx
+++ b/components/tech-comparison/radar-view.tsx
@@ -7,28 +7,105 @@ import {
   PolarRadiusAxis,
   ResponsiveContainer,
   Legend,
+  Tooltip,
 } from "recharts";
 import { TechItem, RatingType } from "@/types/tech-comparison";
 
-export interface RadarViewProps {
-  item: TechItem;
-  ratingTypes: RatingType[];
+const RADAR_COLORS = ["#0ea5e9", "#6366f1", "#10b981", "#f97316", "#a855f7", "#ef4444"] as const;
+
+export interface RadarChartDataPoint {
+  metric: string;
+  [dataKey: string]: number | string;
 }
 
-export function RadarView({ item, ratingTypes }: RadarViewProps): React.ReactElement {
-  const data = ratingTypes.map((rt) => ({
-    metric: rt.label,
-    value: item.ratings[rt.id] ?? 0,
-  }));
+export interface RadarViewProps {
+  items: TechItem[];
+  ratingTypes: RatingType[];
+  maxSeries?: number;
+}
+
+const DEFAULT_MAX_SERIES = 5;
+
+/**
+ * Transforms the provided items and rating types into a Recharts-friendly dataset.
+ */
+export function buildRadarChartData(
+  items: TechItem[],
+  ratingTypes: RatingType[]
+): RadarChartDataPoint[] {
+  return ratingTypes.map((ratingType) => {
+    const entry: RadarChartDataPoint = { metric: ratingType.label };
+
+    items.forEach((techItem) => {
+      entry[techItem.id] = techItem.ratings[ratingType.id] ?? 0;
+    });
+
+    return entry;
+  });
+}
+
+interface RadarSeriesConfig {
+  dataKey: string;
+  name: string;
+  stroke: string;
+  fill: string;
+}
+
+function createSeriesConfig(items: TechItem[]): RadarSeriesConfig[] {
+  return items.map((techItem, index) => {
+    const color = RADAR_COLORS[index % RADAR_COLORS.length];
+
+    return {
+      dataKey: techItem.id,
+      name: techItem.name,
+      stroke: color,
+      fill: color,
+    };
+  });
+}
+
+export function RadarView({
+  items,
+  ratingTypes,
+  maxSeries = DEFAULT_MAX_SERIES,
+}: RadarViewProps): React.ReactElement {
+  const itemsToDisplay = React.useMemo<TechItem[]>(() => items.slice(0, maxSeries), [items, maxSeries]);
+  const chartData = React.useMemo<RadarChartDataPoint[]>(
+    () => buildRadarChartData(itemsToDisplay, ratingTypes),
+    [itemsToDisplay, ratingTypes]
+  );
+  const seriesConfig = React.useMemo<RadarSeriesConfig[]>(
+    () => createSeriesConfig(itemsToDisplay),
+    [itemsToDisplay]
+  );
+
+  if (itemsToDisplay.length === 0) {
+    return (
+      <div className="flex h-72 w-full items-center justify-center rounded-lg border border-dashed border-muted-foreground/30 bg-muted/20 text-sm text-muted-foreground">
+        No comparison data available.
+      </div>
+    );
+  }
 
   return (
     <div className="h-72 w-full">
       <ResponsiveContainer>
-        <RadarChart data={data} margin={{ top: 16, right: 16, bottom: 16, left: 16 }}>
+        <RadarChart data={chartData} margin={{ top: 16, right: 24, bottom: 16, left: 24 }}>
           <PolarGrid />
           <PolarAngleAxis dataKey="metric" tick={{ fontSize: 12 }} />
           <PolarRadiusAxis domain={[0, 5]} tickCount={6} />
-          <Radar name={item.name} dataKey="value" stroke="#0ea5e9" fill="#14b8a6" fillOpacity={0.4} />
+          {seriesConfig.map((series) => (
+            <Radar
+              key={series.dataKey}
+              name={series.name}
+              dataKey={series.dataKey}
+              stroke={series.stroke}
+              strokeWidth={2}
+              fill={series.fill}
+              fillOpacity={0.25}
+            />
+          ))}
+          <Tooltip formatter={(value: number | string) => `${value}/5`} />
           <Legend />
         </RadarChart>
       </ResponsiveContainer>
@@ -37,3 +114,4 @@ export function RadarView({ item, ratingTypes }: RadarViewProps): React.ReactEle
 }
 
 export default RadarView;
+export { DEFAULT_MAX_SERIES as RADAR_DEFAULT_MAX_SERIES };

--- a/components/tech-comparison/tech-comparison-dashboard.test.tsx
+++ b/components/tech-comparison/tech-comparison-dashboard.test.tsx
@@ -9,7 +9,11 @@ vi.mock("./theme-dot", () => ({ __esModule: true, default: () => <div /> }));
 vi.mock("./rating-type-picker", () => ({ __esModule: true, default: () => <div /> }));
 vi.mock("./category-tabs", () => ({ __esModule: true, default: () => <div /> }));
 vi.mock("./item-list", () => ({ __esModule: true, default: () => <div /> }));
-vi.mock("./radar-view", () => ({ __esModule: true, default: () => <div /> }));
+vi.mock("./radar-view", () => ({
+  __esModule: true,
+  default: () => <div />,
+  RADAR_DEFAULT_MAX_SERIES: 5,
+}));
 vi.mock("./bar-summary", () => ({ __esModule: true, default: () => <div /> }));
 vi.mock("@/components/ui/card", () => ({
   Card: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,

--- a/components/tech-comparison/tech-comparison-dashboard.tsx
+++ b/components/tech-comparison/tech-comparison-dashboard.tsx
@@ -8,7 +8,7 @@ import ThemeDot from "./theme-dot";
 import RatingTypePicker from "./rating-type-picker";
 import CategoryTabs from "./category-tabs";
 import ItemList from "./item-list";
-import RadarView from "./radar-view";
+import RadarView, { RADAR_DEFAULT_MAX_SERIES } from "./radar-view";
 import BarSummary from "./bar-summary";
 import { useTechComparison } from "@/hooks/use-tech-comparison";
 import { TechComparisonData } from "@/types/tech-comparison";
@@ -26,11 +26,18 @@ export function TechComparisonDashboard({ data }: TechComparisonDashboardProps):
     selectedCategory,
     setSelectedCategory,
     filteredItems,
-    topItem,
+    topItems,
     categoriesById,
+    selectedCategoryLabel,
   } = useTechComparison(data);
   const selectedRatingLabel =
     ratingTypes.find((r) => r.id === selectedRating)?.label ?? selectedRating;
+  const topCount = Math.min(topItems.length, RADAR_DEFAULT_MAX_SERIES);
+  const stackLabel = topCount === 1 ? "stack" : "stacks";
+  const radarDescription =
+    topItems.length > 0
+      ? `Top ${topCount} ${stackLabel} across all metrics`
+      : "No stacks available in this category";
 
   return (
     <TooltipProvider>
@@ -77,17 +84,15 @@ export function TechComparisonDashboard({ data }: TechComparisonDashboardProps):
             </CardContent>
           </Card>
 
-          {topItem ? (
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-lg">{topItem.name}: Full Profile</CardTitle>
-                <CardDescription>Compare all five dimensions</CardDescription>
-              </CardHeader>
-              <CardContent>
-                <RadarView item={topItem} ratingTypes={ratingTypes} />
-              </CardContent>
-            </Card>
-          ) : null}
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-lg">{selectedCategoryLabel} comparison</CardTitle>
+              <CardDescription>{radarDescription}</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <RadarView items={topItems} ratingTypes={ratingTypes} />
+            </CardContent>
+          </Card>
         </div>
 
         <div className="space-y-3">

--- a/hooks/use-tech-comparison.test.tsx
+++ b/hooks/use-tech-comparison.test.tsx
@@ -96,6 +96,8 @@ describe("useTechComparison", () => {
 
     expect(latest?.selectedRating).toBe("proficiency");
     expect(latest?.filteredItems.map((item) => item.id)).toEqual(["1", "2", "3"]);
+    expect(latest?.topItems.map((item) => item.id)).toEqual(["1", "2", "3"]);
+    expect(latest?.selectedCategoryLabel).toBe("All categories");
 
     await act(async () => {
       latest?.setSelectedRating("recency");
@@ -131,6 +133,8 @@ describe("useTechComparison", () => {
     expect(latest?.filteredItems).toHaveLength(1);
     expect(latest?.filteredItems[0]?.id).toBe("2");
     expect(latest?.categoriesById.backend?.label).toBe("Backend");
+    expect(latest?.topItems.map((item) => item.id)).toEqual(["2"]);
+    expect(latest?.selectedCategoryLabel).toBe("Backend");
 
     root.unmount();
     container.remove();
@@ -157,6 +161,71 @@ describe("useTechComparison", () => {
 
     expect(latest?.filteredItems).toHaveLength(0);
     expect(latest?.topItem?.id).toBe("1");
+    expect(latest?.topItems).toEqual([]);
+    expect(latest?.selectedCategoryLabel).toBe("Operations");
+
+    root.unmount();
+    container.remove();
+  });
+
+  it("limits the number of top items returned", async () => {
+    const data = createTestData();
+    data.items.push(
+      {
+        id: "4",
+        name: "Next.js",
+        type: "Framework",
+        category: "frontend",
+        ratings: {
+          proficiency: 5,
+          production_use: 5,
+          recency: 4,
+          depth: 5,
+          preference: 5,
+        },
+      },
+      {
+        id: "5",
+        name: "Remix",
+        type: "Framework",
+        category: "frontend",
+        ratings: {
+          proficiency: 4,
+          production_use: 3,
+          recency: 3,
+          depth: 3,
+          preference: 4,
+        },
+      },
+      {
+        id: "6",
+        name: "SolidStart",
+        type: "Framework",
+        category: "frontend",
+        ratings: {
+          proficiency: 4,
+          production_use: 2,
+          recency: 4,
+          depth: 3,
+          preference: 4,
+        },
+      }
+    );
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    let latest: UseTechComparisonResult | undefined;
+    const handleRender = (value: UseTechComparisonResult): void => {
+      latest = value;
+    };
+
+    await act(async () => {
+      root.render(<HookTestComponent data={data} onRender={handleRender} />);
+    });
+
+    expect(latest?.topItems).toHaveLength(5);
 
     root.unmount();
     container.remove();

--- a/hooks/use-tech-comparison.ts
+++ b/hooks/use-tech-comparison.ts
@@ -15,7 +15,9 @@ export interface UseTechComparisonResult {
   setSelectedCategory: React.Dispatch<React.SetStateAction<string>>;
   filteredItems: TechItem[];
   topItem: TechItem | undefined;
+  topItems: TechItem[];
   categoriesById: Record<string, Category>;
+  selectedCategoryLabel: string;
 }
 
 /**
@@ -52,6 +54,18 @@ export function useTechComparison(data: TechComparisonData): UseTechComparisonRe
   }, [data.items, selectedCategory, selectedRating]);
 
   const topItem = filteredItems[0] ?? data.items[0];
+  const topItems = React.useMemo<TechItem[]>(
+    () => filteredItems.slice(0, 5),
+    [filteredItems]
+  );
+
+  const selectedCategoryLabel = React.useMemo<string>(() => {
+    if (selectedCategory === "all") {
+      return "All categories";
+    }
+
+    return categoriesById[selectedCategory]?.label ?? selectedCategory;
+  }, [categoriesById, selectedCategory]);
 
   return {
     selectedRating,
@@ -60,7 +74,9 @@ export function useTechComparison(data: TechComparisonData): UseTechComparisonRe
     setSelectedCategory,
     filteredItems,
     topItem,
+    topItems,
     categoriesById,
+    selectedCategoryLabel,
   };
 }
 


### PR DESCRIPTION
## Summary
- update the tech comparison dashboard to feed the radar chart with the top stacks in the selected category and show a contextual description
- extend the radar view component to plot multiple stacks at once, provide a fallback when no data is available, and export helpers for testing
- improve category tabs overflow handling and expand unit test coverage across the updated components and hook

## Testing
- npm test -- --run
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8ad1722a883299edffc7bda77f023