### PR TITLE
Ensure card counter icons use lucide library

### DIFF
--- a/lib/profile-card-counter-data.test.ts
+++ b/lib/profile-card-counter-data.test.ts
@@ -48,4 +48,22 @@ describe("parseCardCounterData", () => {
       })
     ).toThrow(/theme/);
   });
+
+  it("throws when an icon is not part of the lucide-react library", () => {
+    expect(() =>
+      parseCardCounterData({
+        lastUpdated: "2025-01-01",
+        items: [
+          {
+            id: "invalid-icon",
+            title: "Invalid",
+            value: 1,
+            theme: "ocean",
+            order: 1,
+            icon: "FontAwesomeIcon",
+          },
+        ],
+      })
+    ).toThrow(/unsupported icon/);
+  });
 });

--- a/lib/profile-card-counter-data.ts
+++ b/lib/profile-card-counter-data.ts
@@ -1,12 +1,17 @@
 import rawData from "@/public/data/card-counter.json" assert { type: "json" };
+import * as LucideIcons from "lucide-react";
 import {
   COUNTER_CARD_THEMES,
   type CardCounterData,
   type CardCounterItem,
   type CounterCardTheme,
+  type LucideIconName,
 } from "@/types/card-counter";
 
 const COUNTER_CARD_THEME_SET = new Set<string>(COUNTER_CARD_THEMES);
+const LUCIDE_ICON_SET = new Set<LucideIconName>(
+  Object.keys(LucideIcons) as LucideIconName[]
+);
 
 type RawCardCounterItem = {
   id?: unknown;
@@ -25,6 +30,9 @@ type RawCardCounterData = {
 
 const isCounterCardTheme = (value: unknown): value is CounterCardTheme =>
   typeof value === "string" && COUNTER_CARD_THEME_SET.has(value);
+
+const isLucideIconName = (value: unknown): value is LucideIconName =>
+  typeof value === "string" && LUCIDE_ICON_SET.has(value as LucideIconName);
 
 const parseCardCounterItem = (item: unknown, index: number): CardCounterItem => {
   if (!item || typeof item !== "object") {
@@ -74,7 +82,13 @@ const parseCardCounterItem = (item: unknown, index: number): CardCounterItem => 
     parsedItem.description = description;
   }
 
-  if (typeof icon === "string" && icon.trim().length > 0) {
+  if (icon != null) {
+    if (!isLucideIconName(icon)) {
+      throw new Error(
+        `Item at index ${index} references an unsupported icon: ${String(icon)}`
+      );
+    }
+
     parsedItem.icon = icon;
   }
 

--- a/public/data/card-counter.json
+++ b/public/data/card-counter.json
@@ -7,7 +7,7 @@
       "value": 15,
       "description": "Completed across web, data, and ops",
       "theme": "ocean",
-      "icon": "FolderGit2",
+      "icon": "LayoutDashboard",
       "order": 1
     },
     {
@@ -16,7 +16,7 @@
       "value": 120,
       "description": "Core stack + supporting tools",
       "theme": "teal",
-      "icon": "Sparkles",
+      "icon": "Sparkle",
       "order": 2
     },
     {
@@ -43,14 +43,14 @@
       "value": 20,
       "description": "Tech & analytics credentials",
       "theme": "teal",
-      "icon": "BadgeCheck",
+      "icon": "Award",
       "order": 5
     },
     {
       "id": "deployments",
       "title": "Production Deployments",
-      "value": "5+",
-      "description": "Web apps & APIs shipped",
+      "value": 5,
+      "description": "5+ web apps & APIs shipped",
       "theme": "ocean",
       "icon": "Rocket",
       "order": 6
@@ -61,7 +61,7 @@
       "value": 39,
       "description": "Open-source + samples",
       "theme": "cyan",
-      "icon": "Github",
+      "icon": "GitBranch",
       "order": 7
     }
   ]

--- a/types/card-counter.ts
+++ b/types/card-counter.ts
@@ -1,3 +1,7 @@
+import type * as LucideIcons from "lucide-react";
+
+export type LucideIconName = keyof typeof LucideIcons;
+
 export const COUNTER_CARD_THEMES = ["ocean", "teal", "cyan", "ice"] as const;
 
 export type CounterCardTheme = (typeof COUNTER_CARD_THEMES)[number];
@@ -9,7 +13,7 @@ export interface CardCounterItem {
   description?: string;
   theme: CounterCardTheme;
   order: number;
-  icon?: string;
+  icon?: LucideIconName;
 }
 
 export interface CardCounterData {


### PR DESCRIPTION
## Summary
- align the card counter JSON data with lucide-react icons and fix the deployment count value
- type card counter icon fields against lucide-react and validate icon names when parsing data
- add a unit test covering the invalid icon case to guard against future regressions

## Testing
- npm run lint
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68c8b1b8ab548329af5bb3770af6b121