### PR TITLE
Add icon support to profile card counters

### DIFF
--- a/components/card/CardCounter.test.tsx
+++ b/components/card/CardCounter.test.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { describe, it, expect } from "vitest";
+import { act } from "react-dom/test-utils";
+import { createRoot } from "react-dom/client";
+
+import CounterCard from "./CardCounter";
+
+(globalThis as { React?: typeof React }).React = React;
+
+describe("CounterCard", () => {
+  it("renders the provided icon within the accent dot", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <CounterCard count={10} title="Test Counter" icon="Sparkle" />
+      );
+    });
+
+    const iconElement = container.querySelector(
+      'span[aria-hidden="true"] svg.lucide-sparkle'
+    );
+
+    expect(iconElement).not.toBeNull();
+
+    root.unmount();
+    container.remove();
+  });
+});

--- a/components/card/CardCounter.tsx
+++ b/components/card/CardCounter.tsx
@@ -1,5 +1,6 @@
 // components/counter-card.tsx
 import { type ReactElement } from "react";
+import * as LucideIcons from "lucide-react";
 import {
   Card,
   CardHeader,
@@ -8,7 +9,10 @@ import {
   CardContent,
 } from "@/components/ui/card";
 import { cn } from "@/lib/cn";
-import { type CounterCardTheme } from "@/types/card-counter";
+import {
+  type CounterCardTheme,
+  type LucideIconName,
+} from "@/types/card-counter";
 
 const THEME_STYLES: Record<
   CounterCardTheme,
@@ -53,6 +57,9 @@ const THEME_STYLES: Record<
   },
 };
 
+/**
+ * Props for rendering a counter card with an optional Lucide icon accent.
+ */
 export type CounterCardProps = {
   count: number | string;
   title: string;
@@ -62,6 +69,8 @@ export type CounterCardProps = {
   theme?: CounterCardTheme;
   /** Optional override to tweak the accent dot per-instance. */
   dotClassName?: string;
+  /** Optional icon rendered inside the accent dot. */
+  icon?: LucideIconName;
 };
 
 export default function CounterCard({
@@ -71,11 +80,13 @@ export default function CounterCard({
   className,
   theme = "ocean",
   dotClassName,
+  icon,
 }: CounterCardProps): ReactElement {
   const formatted =
     typeof count === "number" ? count.toLocaleString() : String(count);
 
   const style = THEME_STYLES[theme];
+  const Icon = icon ? LucideIcons[icon] : null;
 
   return (
     <Card className={cn("relative pt-6 pl-12", className)}>
@@ -87,7 +98,9 @@ export default function CounterCard({
           style.dot,
           dotClassName
         )}
-      />
+      >
+        {Icon ? <Icon aria-hidden="true" className="h-4 w-4 text-white" /> : null}
+      </span>
       <CardHeader className="p-0">
         <CardTitle className={cn("text-sm font-medium text-muted-foreground", style.title)}>
           {title}

--- a/components/profile/card-counters.test.tsx
+++ b/components/profile/card-counters.test.tsx
@@ -6,6 +6,11 @@ import CardCounters from "./card-counters";
 import { getCardCounterData } from "@/lib/profile-card-counter-data";
 import { type CardCounterData } from "@/types/card-counter";
 
+const toLucideClassName = (iconName: string): string =>
+  `lucide-${iconName
+    .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+    .toLowerCase()}`;
+
 // Ensure React is available globally for components using the new JSX runtime
 (globalThis as { React?: typeof React }).React = React;
 
@@ -23,6 +28,14 @@ describe("CardCounters", () => {
     data.items.forEach((item) => {
       expect(container.textContent).toContain(item.title);
       expect(container.textContent).toContain(item.value.toLocaleString());
+
+      if (item.icon) {
+        const iconElement = container.querySelector(
+          `svg.${toLucideClassName(item.icon)}`
+        );
+
+        expect(iconElement).not.toBeNull();
+      }
     });
 
     root.unmount();

--- a/components/profile/card-counters.tsx
+++ b/components/profile/card-counters.tsx
@@ -25,13 +25,14 @@ export default function CardCounters(): ReactElement {
 
   return (
     <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-      {items.map(({ id, title, value, description, theme }) => (
+      {items.map(({ id, title, value, description, theme, icon }) => (
         <CounterCard
           key={id}
           count={value}
           title={title}
           description={description}
           theme={theme}
+          icon={icon}
         />
       ))}
     </section>


### PR DESCRIPTION
## Summary
- allow CounterCard to render Lucide icons inside its accent dot and extend props
- pass through icon data from profile card counters and cover with tests

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8b713f21c8329baebe8d8a109aa95