### PR TITLE
Revamp tech comparison category tabs and icons

### DIFF
--- a/components/tech-comparison/category-icon.test.tsx
+++ b/components/tech-comparison/category-icon.test.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { createRoot } from "react-dom/client";
+import { act } from "react-dom/test-utils";
+
+vi.mock("lucide-react", () => ({
+  __esModule: true,
+  Sparkles: ({ ...props }: React.SVGProps<SVGSVGElement>) => <svg data-icon="sparkles" {...props} />,
+  Layers3: ({ ...props }: React.SVGProps<SVGSVGElement>) => <svg data-icon="layers-3" {...props} />,
+  LayoutDashboard: ({ ...props }: React.SVGProps<SVGSVGElement>) => (
+    <svg data-icon="layout-dashboard" {...props} />
+  ),
+  Server: ({ ...props }: React.SVGProps<SVGSVGElement>) => <svg data-icon="server" {...props} />,
+  Database: ({ ...props }: React.SVGProps<SVGSVGElement>) => <svg data-icon="database" {...props} />,
+  BarChartBig: ({ ...props }: React.SVGProps<SVGSVGElement>) => <svg data-icon="bar-chart-big" {...props} />,
+  Cog: ({ ...props }: React.SVGProps<SVGSVGElement>) => <svg data-icon="cog" {...props} />,
+  Map: ({ ...props }: React.SVGProps<SVGSVGElement>) => <svg data-icon="map" {...props} />,
+  GitGraph: ({ ...props }: React.SVGProps<SVGSVGElement>) => <svg data-icon="git-graph" {...props} />,
+  Code2: ({ ...props }: React.SVGProps<SVGSVGElement>) => <svg data-icon="code-2" {...props} />,
+}));
+
+import { CategoryIcon } from "./category-icon";
+
+(globalThis as { React?: typeof React }).React = React;
+
+describe("CategoryIcon", () => {
+  it("renders mapped icon for known categories", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<CategoryIcon categoryId="fullstack" />);
+    });
+
+    const icon = container.querySelector("svg[data-icon='layers-3']");
+    expect(icon).not.toBeNull();
+
+    root.unmount();
+    container.remove();
+  });
+
+  it("falls back to a default icon when category is unknown", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<CategoryIcon categoryId="unknown" className="text-red-500" />);
+    });
+
+    const icon = container.querySelector("svg[data-icon='sparkles']");
+    expect(icon).not.toBeNull();
+    expect(icon?.getAttribute("class") ?? "").toContain("text-red-500");
+
+    root.unmount();
+    container.remove();
+  });
+});

--- a/components/tech-comparison/category-icon.tsx
+++ b/components/tech-comparison/category-icon.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import type { LucideIcon } from "lucide-react";
+import {
+  Sparkles,
+  Layers3,
+  LayoutDashboard,
+  Server,
+  Database,
+  BarChartBig,
+  Cog,
+  Map,
+  GitGraph,
+  Code2,
+} from "lucide-react";
+import { cn } from "@/lib/cn";
+import { Category } from "@/types/tech-comparison";
+
+const CATEGORY_ICON_MAP: Partial<Record<Category["id"], LucideIcon>> = {
+  fullstack: Layers3,
+  frontend: LayoutDashboard,
+  backend: Server,
+  database: Database,
+  data_analytics: BarChartBig,
+  devops: Cog,
+  mapping: Map,
+  graphql: GitGraph,
+  languages: Code2,
+};
+
+const FALLBACK_ICON = Sparkles;
+
+export interface CategoryIconProps {
+  categoryId: Category["id"];
+  className?: string;
+}
+
+/**
+ * Renders a Lucide icon that corresponds to a technology category, falling back to a sparkle icon when no mapping exists.
+ */
+export function CategoryIcon({ categoryId, className }: CategoryIconProps): React.ReactElement {
+  const Icon = CATEGORY_ICON_MAP[categoryId] ?? FALLBACK_ICON;
+  return <Icon aria-hidden className={cn("size-4 text-muted-foreground", className)} />;
+}
+
+export default CategoryIcon;

--- a/components/tech-comparison/category-tabs.test.tsx
+++ b/components/tech-comparison/category-tabs.test.tsx
@@ -23,6 +23,16 @@ vi.mock("@/components/ui/tabs", () => ({
   ),
 }));
 
+vi.mock("./category-icon", () => ({
+  __esModule: true,
+  CategoryIcon: ({ categoryId }: { categoryId: string }) => (
+    <span data-testid={`icon-${categoryId}`} />
+  ),
+  default: ({ categoryId }: { categoryId: string }) => (
+    <span data-testid={`icon-${categoryId}`} />
+  ),
+}));
+
 (globalThis as { React?: typeof React }).React = React;
 
 describe("CategoryTabs", () => {
@@ -45,7 +55,7 @@ describe("CategoryTabs", () => {
     container.remove();
   });
 
-  it("applies overflow handling classes", async () => {
+  it("applies overflow handling classes and renders icons", async () => {
     const categories: Category[] = [
       { id: "web", label: "Web" },
       { id: "mobile", label: "Mobile" },
@@ -63,12 +73,20 @@ describe("CategoryTabs", () => {
 
     const list = container.querySelector<HTMLDivElement>("[data-component='tabs-list']");
     const triggers = container.querySelectorAll<HTMLButtonElement>("[data-component='tabs-trigger']");
+    const firstCategoryIcon = container.querySelector("[data-testid='icon-web']");
+    const allTrigger = container.querySelector<HTMLButtonElement>("button[value='all']");
+    const gradientOverlays = container.querySelectorAll("span[aria-hidden='true']");
 
     expect(list?.className).toContain("overflow-x-auto");
+    expect(list?.className).toContain("[&::-webkit-scrollbar]:hidden");
     expect(list?.getAttribute("aria-label")).toBe("Technology categories");
     triggers.forEach((trigger) => {
       expect(trigger.className).toContain("flex-none");
+      expect(trigger.className).toContain("rounded-full");
     });
+    expect(firstCategoryIcon).not.toBeNull();
+    expect(allTrigger?.querySelector("svg")).not.toBeNull();
+    expect(gradientOverlays.length).toBeGreaterThanOrEqual(2);
 
     root.unmount();
     container.remove();

--- a/components/tech-comparison/category-tabs.tsx
+++ b/components/tech-comparison/category-tabs.tsx
@@ -1,6 +1,20 @@
 import React from "react";
+import { Sparkles } from "lucide-react";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Category } from "@/types/tech-comparison";
+import { CategoryIcon } from "./category-icon";
+
+const LIST_SCROLL_CLASSES =
+  "flex w-full min-w-full flex-nowrap gap-2 overflow-x-auto rounded-full border border-gray-200 bg-gray-50/80 p-1 pl-3 pr-3 text-sm shadow-inner shadow-gray-200/50 dark:border-gray-700 dark:bg-gray-800/60 dark:shadow-black/20 [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden";
+
+const TRIGGER_CLASSES =
+  "group flex-none items-center gap-2 rounded-full px-4 py-2 text-sm font-medium transition-colors whitespace-nowrap data-[state=active]:border-gray-200 data-[state=active]:bg-white data-[state=active]:text-teal-600 dark:data-[state=active]:border-gray-700 dark:data-[state=active]:bg-gray-900 dark:data-[state=active]:text-cyan-300";
+
+const CATEGORY_ICON_CLASSES =
+  "size-4 text-gray-500 transition-colors group-data-[state=active]:text-teal-600 dark:text-gray-400 dark:group-data-[state=active]:text-cyan-300";
+
+const ALL_ICON_CLASSES =
+  "size-4 text-teal-500 transition-colors group-data-[state=active]:text-teal-600 dark:text-cyan-400 dark:group-data-[state=active]:text-cyan-300";
 
 export interface CategoryTabsProps {
   categories: Category[];
@@ -11,23 +25,35 @@ export interface CategoryTabsProps {
 export function CategoryTabs({ categories, value, onValueChange }: CategoryTabsProps): React.ReactElement {
   return (
     <Tabs value={value} onValueChange={onValueChange} className="w-full">
-      <TabsList
-        aria-label="Technology categories"
-        className="flex w-full flex-nowrap gap-2 overflow-x-auto pb-1"
-      >
-        <TabsTrigger value="all" className="flex-none whitespace-nowrap px-3">
-          All
-        </TabsTrigger>
-        {categories.map((c) => (
+      <div className="relative overflow-hidden">
+        <TabsList aria-label="Technology categories" className={LIST_SCROLL_CLASSES}>
           <TabsTrigger
-            key={c.id}
-            value={c.id}
-            className="flex-none whitespace-nowrap px-3"
+            value="all"
+            className={TRIGGER_CLASSES}
           >
-            {c.label}
+            <Sparkles aria-hidden className={ALL_ICON_CLASSES} />
+            <span>All</span>
           </TabsTrigger>
-        ))}
-      </TabsList>
+          {categories.map((c) => (
+            <TabsTrigger
+              key={c.id}
+              value={c.id}
+              className={TRIGGER_CLASSES}
+            >
+              <CategoryIcon categoryId={c.id} className={CATEGORY_ICON_CLASSES} />
+              <span>{c.label}</span>
+            </TabsTrigger>
+          ))}
+        </TabsList>
+        <span
+          aria-hidden
+          className="pointer-events-none absolute inset-y-1 left-0 w-8 rounded-l-full bg-gradient-to-r from-white to-transparent dark:from-gray-900 z-10"
+        />
+        <span
+          aria-hidden
+          className="pointer-events-none absolute inset-y-1 right-0 w-8 rounded-r-full bg-gradient-to-l from-white to-transparent dark:from-gray-900 z-10"
+        />
+      </div>
     </Tabs>
   );
 }

--- a/components/tech-comparison/index.ts
+++ b/components/tech-comparison/index.ts
@@ -1,2 +1,3 @@
 export { default as TechComparisonDashboard } from "./tech-comparison-dashboard";
 export { type TechComparisonData } from "@/types/tech-comparison";
+export { CategoryIcon } from "./category-icon";

--- a/components/tech-comparison/item-list.test.tsx
+++ b/components/tech-comparison/item-list.test.tsx
@@ -20,7 +20,9 @@ vi.mock("@/components/ui/card", () => ({
 }));
 
 vi.mock("@/components/ui/badge", () => ({
-  Badge: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  Badge: ({ children, ...props }: { children: React.ReactNode } & React.HTMLAttributes<HTMLSpanElement>) => (
+    <span {...props}>{children}</span>
+  ),
 }));
 
 vi.mock("./theme-dot", () => ({
@@ -36,6 +38,16 @@ vi.mock("./star-rating", () => ({
 vi.mock("./rating-bar", () => ({
   __esModule: true,
   default: () => <div />,
+}));
+
+vi.mock("./category-icon", () => ({
+  __esModule: true,
+  CategoryIcon: ({ categoryId }: { categoryId: string }) => (
+    <span data-testid={`category-icon-${categoryId}`} />
+  ),
+  default: ({ categoryId }: { categoryId: string }) => (
+    <span data-testid={`category-icon-${categoryId}`} />
+  ),
 }));
 
 (globalThis as { React?: typeof React }).React = React;
@@ -67,6 +79,7 @@ describe("ItemList", () => {
     });
 
     expect(container.textContent).toContain("React");
+    expect(container.querySelector("[data-testid='category-icon-web']")).not.toBeNull();
 
     root.unmount();
     container.remove();

--- a/components/tech-comparison/item-list.tsx
+++ b/components/tech-comparison/item-list.tsx
@@ -5,6 +5,7 @@ import { Badge } from "@/components/ui/badge";
 import ThemeDot from "./theme-dot";
 import StarRating from "./star-rating";
 import RatingBar from "./rating-bar";
+import { CategoryIcon } from "./category-icon";
 import { TechItem, RatingTypesId, Category } from "@/types/tech-comparison";
 
 export interface ItemListProps {
@@ -28,8 +29,15 @@ export function ItemList({ items, selectedRating, categoriesById }: ItemListProp
                 <CardDescription className="flex items-center gap-2">
                   <Badge variant="secondary">{it.type}</Badge>
                   {cat?.label ? (
-                    <Badge style={{ backgroundColor: cat.color ?? undefined }} className="text-white">
-                      {cat.label}
+                    <Badge
+                      style={{ backgroundColor: cat.color ?? undefined }}
+                      className="flex items-center gap-1 text-white"
+                    >
+                      <CategoryIcon
+                        categoryId={cat.id}
+                        className="size-3.5 text-white/90"
+                      />
+                      <span>{cat.label}</span>
                     </Badge>
                   ) : null}
                 </CardDescription>


### PR DESCRIPTION
## Summary
- redesign the tech comparison category tabs with hidden scrollbars, gradient edges, and iconography for each segment
- introduce a reusable CategoryIcon component and reuse it on item badges to highlight category context
- expand unit coverage around the tabs, item list, and new icon mapping

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca21a10ea48329beb2e3fc86f758de