### PR TITLE
Fix project details slug params typing

### DIFF
--- a/app/project-details/[slug]/page.test.tsx
+++ b/app/project-details/[slug]/page.test.tsx
@@ -12,7 +12,7 @@ describe("ProjectDetailPage", () => {
     const { default: ProjectDetailPage } = await import("./page");
     const { notFound } = await import("next/navigation");
 
-    await ProjectDetailPage({ params: { slug: "missing" } });
+    await ProjectDetailPage({ params: Promise.resolve({ slug: "missing" }) });
 
     expect(notFound).toHaveBeenCalled();
   });
@@ -20,7 +20,9 @@ describe("ProjectDetailPage", () => {
   it("generates metadata for known project", async () => {
     const { generateMetadata } = await import("./page");
 
-    const metadata = await generateMetadata({ params: { slug: "ai-coin-detector" } });
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ slug: "ai-coin-detector" }),
+    });
 
     expect(metadata.title).toContain("AI Coin Detector");
     expect(metadata.description).toContain("Django");


### PR DESCRIPTION
## Summary
- normalize project detail page params handling to satisfy Next.js generated types
- document and type the slug param resolver and static params generator
- update the project detail route tests to pass the promise-wrapped params

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbaa2f1e348329887097ef3a2cf208