### PR TITLE
Fix Awards page JSX namespace error

### DIFF
--- a/app/awards/page.tsx
+++ b/app/awards/page.tsx
@@ -1,9 +1,7 @@
-import React from "react";
+import React, { type ReactElement } from "react";
 import type { Metadata } from "next";
 
 import Awards from "@/components/awards";
-
-void React;
 
 const PAGE_TITLE = "Awards | Seanne Cañete";
 const PAGE_DESCRIPTION =
@@ -24,7 +22,7 @@ export const metadata: Metadata = {
   },
 };
 
-export default function AwardsPage(): JSX.Element {
+export default function AwardsPage(): ReactElement {
   return (
     <main className="container mx-auto max-w-5xl px-4 py-12">
       <Awards />


### PR DESCRIPTION
## Summary
- import React alongside ReactElement in the awards page to restore runtime JSX scope
- retain explicit ReactElement return type to satisfy TypeScript configuration

## Testing
- npm run lint
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68cbaf73d080832991a8313b0a57dc81