### PR TITLE
Restore Next.js TypeScript environment types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,3 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
-next-env.d.ts

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary
- add the missing `next-env.d.ts` file so Next.js provides JSX type definitions during builds
- update `.gitignore` to ensure the generated environment type file is committed going forward

## Testing
- npm run lint
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68cbb4aeec9883299a405ce11e18cda5