### PR TITLE
fix: add JSX type imports to pages

### DIFF
--- a/app/certificates/page.tsx
+++ b/app/certificates/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import type { JSX } from "react";
 
 import Certificates from "@/components/certificates";
 

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import type { JSX } from "react";
 
 import ContactPageContent from "@/components/contact/contact-page-content";
 

--- a/app/courses/page.tsx
+++ b/app/courses/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import type { JSX } from "react";
 
 import CoursesSection from "@/components/courses";
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import type { JSX } from "react";
 
 import HomePageContent from "@/components/home/home-page-content";
 

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import type { JSX } from "react";
 
 import Profile, { CardCounters, MyStory } from "@/components/profile";
 import OtherSkills from "@/components/profile/OtherSkills";

--- a/app/project-details/[slug]/page.tsx
+++ b/app/project-details/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import type { ComponentType } from "react";
+import type { JSX } from "react";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import type { JSX } from "react";
 
 import ProjectsPageContent from "@/components/projects/projects-page-content";
 

--- a/app/work-experiences/page.tsx
+++ b/app/work-experiences/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import type { JSX } from "react";
 
 import WorkExperiences from "@/components/work-experiences";
 

--- a/components/contact/contact-page-content.tsx
+++ b/components/contact/contact-page-content.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { JSX } from "react";
 import { useState } from "react";
 import { Github, Linkedin, Mail, Phone, Twitter } from "lucide-react";
 

--- a/components/home/home-page-content.tsx
+++ b/components/home/home-page-content.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { JSX } from "react";
 import Link from "next/link";
 import { toast } from "sonner";
 

--- a/components/projects/projects-page-content.tsx
+++ b/components/projects/projects-page-content.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { JSX } from "react";
 import { useMemo, useState } from "react";
 import { motion } from "framer-motion";
 import Image from "next/image";


### PR DESCRIPTION
## Summary
- import the React JSX namespace into Next.js route files that reference JSX.Element types
- add the same JSX type import to client components that declare JSX.Element return types to satisfy the compiler

## Testing
- npm run lint
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbb6d1abf8832980ebb957fd26474e