### PR TITLE
Enhance header navigation for mobile devices

### DIFF
--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -15,12 +15,8 @@ import { ModeToggle } from "@/components/mode-toggle";
 import { Github, Linkedin, Twitter } from "lucide-react";
 import { withBasePath } from "@/lib/utils";
 import { toast } from "sonner";
-
-type NavLink = {
-  href: string;
-  label: string;
-  external?: boolean;
-};
+import { MobileNav } from "@/components/layout/mobile-nav";
+import type { NavLink, SocialLink } from "@/types/navigation";
 
 const NAV_LINKS = [
   { href: "/", label: "Home" },
@@ -53,131 +49,145 @@ const SOCIAL_LINKS = [
     label: "LinkedIn",
     icon: Linkedin,
   },
-] as const;
+] as const satisfies readonly SocialLink[];
 
 export default function Header(): ReactElement {
   const pathname = usePathname();
   const [hovered, setHovered] = React.useState<string | null>(null);
+  const handleLinkFollow = React.useCallback((link: NavLink): void => {
+    if (link.external) {
+      toast.info("Opening resume…");
+    }
+  }, []);
 
   return (
     <header className="relative z-50 border-b bg-gradient-to-r from-teal-600/15 to-transparent dark:from-teal-400/15 dark:to-transparent">
       <span className="pointer-events-none absolute inset-0 dot-pattern opacity-20 blur-sm" />
-      <div className="relative container mx-auto flex h-16 items-center justify-between px-4">
+      <div className="relative container mx-auto flex h-16 items-center justify-between px-4 sm:h-[4.5rem] md:h-20">
         {/* Brand */}
         <Link
           href="/"
-          className="text-lg font-semibold text-black dark:text-white hover:opacity-90"
+          className="text-base font-semibold text-black transition hover:opacity-90 dark:text-white sm:text-lg"
         >
           Dev Portfolio
         </Link>
-
-        <div className="flex items-center gap-3">
-          {/* Links row */}
-          <NavigationMenu>
-            <NavigationMenuList
-              // group + arbitrary selectors to affect siblings when the list is hovered
-              className={[
-                "group flex items-center gap-1 transition-[gap] duration-300",
-                "group-hover:gap-3",
-                // fade/scale non-hovered items when any item is hovered
-                "[&>li]:transition [&>li]:duration-300",
-                "group-hover:[&>li:not(:hover)]:opacity-60",
-                "group-hover:[&>li:not(:hover)]:scale-95",
-              ].join(" ")}
-            >
-              {NAV_LINKS.map((link: NavLink) => {
-                const { href, label, external } = link;
-                const isActive =
-                  !external && (pathname === href || (href !== "/" && pathname?.startsWith(href)));
-                const isHot = hovered === href || isActive;
-
-                return (
-                  <NavigationMenuItem
-                    key={href}
-                    onMouseEnter={() => setHovered(href)}
-                    onMouseLeave={() => setHovered((prev) => (prev === href ? null : prev))}
-                  >
-                    <NavigationMenuLink asChild>
-                      {external ? (
-                        <a
-                          href={href}
-                          target="_blank"
-                          rel="noreferrer"
-                          onClick={() => toast.info("Opening resume…")}
-                          className={[
-                            "relative block rounded-md px-3 py-1.5 text-sm font-medium transition",
-                            "text-black dark:text-white",
-                            "hover:-translate-y-0.5 hover:shadow-sm",
-                            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/50 dark:focus-visible:ring-white/50",
-                            "after:absolute after:inset-x-2 after:-bottom-0.5 after:h-0.5 after:rounded-full after:scale-x-0",
-                            "after:origin-left after:transition-transform after:duration-300",
-                            "after:bg-teal-600/80 dark:after:bg-teal-400/80",
-                            "hover:after:scale-x-100",
-                          ].join(" ")}
-                        >
-                          {isHot && (
-                            <motion.span
-                              layoutId="nav-pill"
-                              className="absolute inset-0 -z-10 rounded-md bg-teal-600/10 ring-1 ring-teal-600/25 dark:bg-teal-400/10 dark:ring-teal-400/25"
-                              transition={{ type: "spring", stiffness: 500, damping: 35, mass: 0.3 }}
-                            />
-                          )}
-                          {label}
-                        </a>
-                      ) : (
-                        <Link
-                          href={href}
-                          aria-current={isActive ? "page" : undefined}
-                          className={[
-                            "relative block rounded-md px-3 py-1.5 text-sm font-medium transition",
-                            "text-black dark:text-white",
-                            "hover:-translate-y-0.5 hover:shadow-sm",
-                            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/50 dark:focus-visible:ring-white/50",
-                            // active page: teal text + subtle ring
-                            "aria-[current=page]:text-teal-700 dark:aria-[current=page]:text-teal-300",
-                            "aria-[current=page]:ring-1 aria-[current=page]:ring-teal-500/40 dark:aria-[current=page]:ring-teal-400/30",
-                            // underline that grows in
-                            "after:absolute after:inset-x-2 after:-bottom-0.5 after:h-0.5 after:rounded-full after:scale-x-0",
-                            "after:origin-left after:transition-transform after:duration-300",
-                            "after:bg-teal-600/80 dark:after:bg-teal-400/80",
-                            "hover:after:scale-x-100 aria-[current=page]:after:scale-x-100",
-                          ].join(" ")}
-                        >
-                          {/* Animated pill highlight on hover/active */}
-                          {isHot && (
-                            <motion.span
-                              layoutId="nav-pill"
-                              className="absolute inset-0 -z-10 rounded-md bg-teal-600/10 ring-1 ring-teal-600/25 dark:bg-teal-400/10 dark:ring-teal-400/25"
-                              transition={{ type: "spring", stiffness: 500, damping: 35, mass: 0.3 }}
-                            />
-                          )}
-                          {label}
-                        </Link>
-                      )}
-                    </NavigationMenuLink>
-                  </NavigationMenuItem>
-                );
-              })}
-            </NavigationMenuList>
-          </NavigationMenu>
-
-          <div className="flex items-center gap-2">
-            {SOCIAL_LINKS.map(({ href, label, icon: Icon }) => (
-              <a
-                key={href}
-                href={href}
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label={label}
-                className="rounded-md p-2 text-black transition hover:-translate-y-0.5 hover:shadow-sm hover:text-teal-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/50 dark:text-white dark:hover:text-teal-400 dark:focus-visible:ring-white/50"
+        <div className="flex items-center gap-2 md:gap-3">
+          <div className="hidden items-center gap-3 md:flex">
+            <NavigationMenu aria-label="Primary navigation">
+              <NavigationMenuList
+                // group + arbitrary selectors to affect siblings when the list is hovered
+                className={[
+                  "group flex items-center gap-1 transition-[gap] duration-300",
+                  "group-hover:gap-3",
+                  // fade/scale non-hovered items when any item is hovered
+                  "[&>li]:transition [&>li]:duration-300",
+                  "group-hover:[&>li:not(:hover)]:opacity-60",
+                  "group-hover:[&>li:not(:hover)]:scale-95",
+                ].join(" ")}
               >
-                <Icon className="h-4 w-4" />
-              </a>
-            ))}
+                {NAV_LINKS.map((link: NavLink) => {
+                  const { href, label, external } = link;
+                  const isActive =
+                    !external && (pathname === href || (href !== "/" && pathname?.startsWith(href)));
+                  const isHot = hovered === href || isActive;
+
+                  return (
+                    <NavigationMenuItem
+                      key={href}
+                      onMouseEnter={() => setHovered(href)}
+                      onMouseLeave={() => setHovered((prev) => (prev === href ? null : prev))}
+                    >
+                      <NavigationMenuLink asChild>
+                        {external ? (
+                          <a
+                            href={href}
+                            target="_blank"
+                            rel="noreferrer"
+                            onClick={() => handleLinkFollow(link)}
+                            className={[
+                              "relative block rounded-md px-3 py-1.5 text-sm font-medium transition",
+                              "text-black dark:text-white",
+                              "hover:-translate-y-0.5 hover:shadow-sm",
+                              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/50 dark:focus-visible:ring-white/50",
+                              "after:absolute after:inset-x-2 after:-bottom-0.5 after:h-0.5 after:rounded-full after:scale-x-0",
+                              "after:origin-left after:transition-transform after:duration-300",
+                              "after:bg-teal-600/80 dark:after:bg-teal-400/80",
+                              "hover:after:scale-x-100",
+                            ].join(" ")}
+                          >
+                            {isHot && (
+                              <motion.span
+                                layoutId="nav-pill"
+                                className="absolute inset-0 -z-10 rounded-md bg-teal-600/10 ring-1 ring-teal-600/25 dark:bg-teal-400/10 dark:ring-teal-400/25"
+                                transition={{ type: "spring", stiffness: 500, damping: 35, mass: 0.3 }}
+                              />
+                            )}
+                            {label}
+                          </a>
+                        ) : (
+                          <Link
+                            href={href}
+                            aria-current={isActive ? "page" : undefined}
+                            className={[
+                              "relative block rounded-md px-3 py-1.5 text-sm font-medium transition",
+                              "text-black dark:text-white",
+                              "hover:-translate-y-0.5 hover:shadow-sm",
+                              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/50 dark:focus-visible:ring-white/50",
+                              // active page: teal text + subtle ring
+                              "aria-[current=page]:text-teal-700 dark:aria-[current=page]:text-teal-300",
+                              "aria-[current=page]:ring-1 aria-[current=page]:ring-teal-500/40 dark:aria-[current=page]:ring-teal-400/30",
+                              // underline that grows in
+                              "after:absolute after:inset-x-2 after:-bottom-0.5 after:h-0.5 after:rounded-full after:scale-x-0",
+                              "after:origin-left after:transition-transform after:duration-300",
+                              "after:bg-teal-600/80 dark:after:bg-teal-400/80",
+                              "hover:after:scale-x-100 aria-[current=page]:after:scale-x-100",
+                            ].join(" ")}
+                          >
+                            {/* Animated pill highlight on hover/active */}
+                            {isHot && (
+                              <motion.span
+                                layoutId="nav-pill"
+                                className="absolute inset-0 -z-10 rounded-md bg-teal-600/10 ring-1 ring-teal-600/25 dark:bg-teal-400/10 dark:ring-teal-400/25"
+                                transition={{ type: "spring", stiffness: 500, damping: 35, mass: 0.3 }}
+                              />
+                            )}
+                            {label}
+                          </Link>
+                        )}
+                      </NavigationMenuLink>
+                    </NavigationMenuItem>
+                  );
+                })}
+              </NavigationMenuList>
+            </NavigationMenu>
+
+            <div className="hidden items-center gap-2 lg:flex">
+              {SOCIAL_LINKS.map(({ href, label, icon: Icon }) => (
+                <a
+                  key={href}
+                  href={href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label={label}
+                  className="rounded-md p-2 text-black transition hover:-translate-y-0.5 hover:shadow-sm hover:text-teal-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/50 dark:text-white dark:hover:text-teal-400 dark:focus-visible:ring-white/50"
+                >
+                  <Icon className="h-4 w-4" />
+                </a>
+              ))}
+            </div>
+
+            <ModeToggle className="text-black hover:opacity-90 dark:text-white" />
           </div>
 
-          {/* Theme toggle */}
-          <ModeToggle className="text-black hover:opacity-90 dark:text-white" />
+          <div className="flex items-center gap-2 md:hidden">
+            <ModeToggle className="text-black hover:opacity-90 dark:text-white" />
+            <MobileNav
+              navLinks={NAV_LINKS}
+              socialLinks={SOCIAL_LINKS}
+              currentPathname={pathname}
+              onLinkFollow={handleLinkFollow}
+            />
+          </div>
         </div>
       </div>
     </header>

--- a/components/layout/mobile-nav.test.tsx
+++ b/components/layout/mobile-nav.test.tsx
@@ -1,0 +1,127 @@
+import React, { type ReactElement } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { act } from "react-dom/test-utils";
+import { createRoot } from "react-dom/client";
+import { Github } from "lucide-react";
+
+vi.mock("next/link", () => {
+  interface MockLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+    href: string;
+    prefetch?: boolean;
+    children: React.ReactNode;
+  }
+
+  const MockLink = React.forwardRef<HTMLAnchorElement, MockLinkProps>(
+    ({ href, children, ...props }, ref): ReactElement => {
+      const { prefetch: _prefetch, ...rest } = props;
+      void _prefetch;
+
+      return (
+        <a ref={ref} href={href} {...rest}>
+          {children}
+        </a>
+      );
+    },
+  );
+
+  MockLink.displayName = "MockNextLink";
+
+  return {
+    __esModule: true,
+    default: MockLink,
+  };
+});
+
+import { MobileNav } from "./mobile-nav";
+import type { NavLink, SocialLink } from "@/types/navigation";
+
+(globalThis as { React?: typeof React }).React = React;
+
+const NAV_LINKS: readonly NavLink[] = [
+  { href: "/", label: "Home" },
+  { href: "/projects", label: "Projects" },
+  { href: "https://example.com/resume.pdf", label: "Resume", external: true },
+];
+
+const SOCIAL_LINKS: readonly SocialLink[] = [
+  { href: "https://github.com/example", label: "GitHub", icon: Github },
+];
+
+describe("MobileNav", () => {
+  it("renders navigation links when opened and marks the active route", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <MobileNav
+          navLinks={NAV_LINKS}
+          socialLinks={SOCIAL_LINKS}
+          currentPathname="/projects"
+        />,
+      );
+    });
+
+    const trigger = container.querySelector<HTMLButtonElement>("button[aria-label='Open navigation']");
+    expect(trigger).not.toBeNull();
+
+    await act(async () => {
+      trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const activeLink = document.body.querySelector<HTMLAnchorElement>("a[href='/projects']");
+    expect(activeLink).not.toBeNull();
+    expect(activeLink?.getAttribute("aria-current")).toBe("page");
+
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("calls the provided callback and closes after selecting a link", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const handleLinkFollow = vi.fn();
+
+    await act(async () => {
+      root.render(
+        <MobileNav
+          navLinks={NAV_LINKS}
+          socialLinks={SOCIAL_LINKS}
+          currentPathname="/"
+          onLinkFollow={handleLinkFollow}
+        />,
+      );
+    });
+
+    const trigger = container.querySelector<HTMLButtonElement>("button[aria-label='Open navigation']");
+    expect(trigger).not.toBeNull();
+
+    await act(async () => {
+      trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(trigger?.getAttribute("aria-expanded")).toBe("true");
+
+    const resumeLink = document.body.querySelector<HTMLAnchorElement>(
+      "a[href='https://example.com/resume.pdf']",
+    );
+    expect(resumeLink).not.toBeNull();
+
+    await act(async () => {
+      resumeLink?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(handleLinkFollow).toHaveBeenCalledWith(
+      expect.objectContaining({ href: "https://example.com/resume.pdf" }),
+    );
+    expect(trigger?.getAttribute("aria-expanded")).toBe("false");
+
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+});

--- a/components/layout/mobile-nav.tsx
+++ b/components/layout/mobile-nav.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import * as React from "react";
+import { type ReactElement } from "react";
+import Link from "next/link";
+import { ArrowUpRight, Menu } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Sheet,
+  SheetContent,
+  SheetTrigger,
+  SheetClose,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from "@/components/ui/sheet";
+import { cn } from "@/lib/utils";
+import type { NavLink, SocialLink } from "@/types/navigation";
+
+interface MobileNavProps {
+  navLinks: readonly NavLink[];
+  socialLinks: readonly SocialLink[];
+  currentPathname: string | null;
+  onLinkFollow?: (link: NavLink) => void;
+}
+
+export function MobileNav({
+  navLinks,
+  socialLinks,
+  currentPathname,
+  onLinkFollow,
+}: MobileNavProps): ReactElement {
+  const [open, setOpen] = React.useState<boolean>(false);
+
+  const handleOpenChange = React.useCallback((nextOpen: boolean) => {
+    setOpen(nextOpen);
+  }, []);
+
+  const handleSelect = React.useCallback(
+    (link: NavLink) => {
+      onLinkFollow?.(link);
+      setOpen(false);
+    },
+    [onLinkFollow],
+  );
+
+  const handleDismiss = React.useCallback(() => {
+    setOpen(false);
+  }, []);
+
+  return (
+    <Sheet open={open} onOpenChange={handleOpenChange}>
+      <SheetTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label="Open navigation"
+          aria-expanded={open}
+          className="text-black hover:text-teal-600 dark:text-white dark:hover:text-teal-400"
+        >
+          <Menu className="h-5 w-5" />
+        </Button>
+      </SheetTrigger>
+      <SheetContent side="left" className="gap-0 p-0">
+        <SheetHeader className="border-b border-gray-200 bg-white px-4 py-4 text-left dark:border-gray-800 dark:bg-gray-900">
+          <SheetTitle className="text-lg font-semibold text-black dark:text-white">
+            Navigation
+          </SheetTitle>
+          <SheetDescription className="text-sm text-gray-600 dark:text-gray-300">
+            Quickly jump to any section or connect with me.
+          </SheetDescription>
+        </SheetHeader>
+        <nav aria-label="Mobile navigation" className="px-2 py-4">
+          <ul className="flex flex-col gap-1">
+            {navLinks.map((link) => {
+              const isActive =
+                !link.external &&
+                (currentPathname === link.href ||
+                  (link.href !== "/" && (currentPathname?.startsWith(link.href) ?? false)));
+
+              const itemClassName = cn(
+                "flex items-center justify-between rounded-md px-3 py-2 text-base font-medium transition",
+                "text-black hover:bg-teal-500/10 hover:text-teal-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500/60",
+                "dark:text-white dark:hover:bg-teal-400/10 dark:hover:text-teal-200",
+                isActive && "bg-teal-500/10 text-teal-700 dark:text-teal-300",
+              );
+
+              const content = (
+                <>
+                  <span>{link.label}</span>
+                  {link.external ? (
+                    <ArrowUpRight className="ml-3 h-4 w-4 text-gray-500 dark:text-gray-400" aria-hidden="true" />
+                  ) : null}
+                </>
+              );
+
+              return (
+                <li key={link.href}>
+                  {link.external ? (
+                    <SheetClose asChild>
+                      <a
+                        href={link.href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={() => handleSelect(link)}
+                        className={itemClassName}
+                      >
+                        {content}
+                      </a>
+                    </SheetClose>
+                  ) : (
+                    <SheetClose asChild>
+                      <Link
+                        href={link.href}
+                        prefetch={false}
+                        aria-current={isActive ? "page" : undefined}
+                        onClick={() => handleSelect(link)}
+                        className={itemClassName}
+                      >
+                        {content}
+                      </Link>
+                    </SheetClose>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        </nav>
+        <div className="border-t border-gray-200 px-4 py-4 dark:border-gray-800">
+          <p className="text-sm font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300">
+            Connect
+          </p>
+          <div className="mt-3 flex items-center gap-3">
+            {socialLinks.map((social) => (
+              <SheetClose asChild key={social.href}>
+                <a
+                  href={social.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label={social.label}
+                  onClick={handleDismiss}
+                  className="rounded-md p-2 text-black transition hover:bg-teal-500/10 hover:text-teal-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500/60 dark:text-white dark:hover:bg-teal-400/10 dark:hover:text-teal-200"
+                >
+                  <social.icon className="h-5 w-5" />
+                </a>
+              </SheetClose>
+            ))}
+          </div>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/types/navigation.ts
+++ b/types/navigation.ts
@@ -1,0 +1,13 @@
+import type { LucideIcon } from "lucide-react";
+
+export interface NavLink {
+  href: string;
+  label: string;
+  external?: boolean;
+}
+
+export interface SocialLink {
+  href: string;
+  label: string;
+  icon: LucideIcon;
+}


### PR DESCRIPTION
## Summary
- add a mobile navigation sheet with social links and shared navigation types
- update the header layout to integrate the mobile drawer and tweak responsive spacing
- cover the mobile navigation interactions with unit tests

## Testing
- npm run lint
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68cfe4dc3b0083298624f62e1f4a875c