### PR TITLE
Add LLM Restaurant Finder project metadata

### DIFF
--- a/app/project-details/[slug]/page.tsx
+++ b/app/project-details/[slug]/page.tsx
@@ -31,7 +31,7 @@ const projectDetailConfig: Record<string, ProjectDetailConfig> = {
     loader: () => import("@/components/project-details/LlmRestaurantFinder"),
     title: "LLM Restaurant Finder",
     description:
-      "Conversational restaurant discovery service orchestrating Gemini JSON commands with the Foursquare Places API.",
+      "LLM-driven dining assistant parsing user intents into validated schemas before querying Foursquare Places so metadata stays precise.",
   },
   "ai-coin-detector": {
     loader: () => import("@/components/project-details/AICoinDetector"),

--- a/components/project-details/llm-restaurant-finder.test.tsx
+++ b/components/project-details/llm-restaurant-finder.test.tsx
@@ -14,8 +14,8 @@ vi.mock("./ProjectGallery", () => ({
 type LlmRestaurantFinderComponent = typeof import("./LlmRestaurantFinder")["default"];
 
 const loadComponent = async (): Promise<LlmRestaurantFinderComponent> => {
-  const module = await import("./LlmRestaurantFinder");
-  return module.default;
+  const componentModule = await import("./LlmRestaurantFinder");
+  return componentModule.default;
 };
 
 (globalThis as { React?: typeof React }).React = React;


### PR DESCRIPTION
## Summary
- register the LLM Restaurant Finder project detail page in the dynamic route map
- summarize the LLM parsing, schema validation, and Foursquare querying workflow in the page metadata
- rename the local import variable in the associated test to satisfy Next.js lint rules

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1e6498b0083299ff59c7d2b4ab83f