### PR TITLE
Update projects card counter data

### DIFF
--- a/public/data/card-counter.json
+++ b/public/data/card-counter.json
@@ -1,10 +1,10 @@
 {
-  "lastUpdated": "2025-09-15",
+  "lastUpdated": "2025-09-23",
   "items": [
     {
       "id": "projects",
       "title": "Projects",
-      "value": 15,
+      "value": 16,
       "description": "Completed across web, data, and ops",
       "theme": "ocean",
       "icon": "LayoutDashboard",


### PR DESCRIPTION
## Summary
- update the projects entry in `public/data/card-counter.json` to reflect the new total and refresh the `lastUpdated` date
- confirmed the dashboard card and its test suite pull values through `getCardCounterData()` so the updated count propagates automatically

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1ec3529e88329b7c2a8463784d6f3