### PR TITLE
Add regression tests for LLM Restaurant Finder metadata and gallery

### DIFF
--- a/app/project-details/[slug]/page.test.tsx
+++ b/app/project-details/[slug]/page.test.tsx
@@ -27,4 +27,15 @@ describe("ProjectDetailPage", () => {
     expect(metadata.title).toContain("AI Coin Detector");
     expect(metadata.description).toContain("Django");
   });
+
+  it("generates metadata for the LLM Restaurant Finder project", async () => {
+    const { generateMetadata } = await import("./page");
+
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ slug: "llm-restaurant-finder" }),
+    });
+
+    expect(metadata.title).toContain("LLM Restaurant Finder");
+    expect(metadata.description).toContain("LLM-driven dining assistant");
+  });
 });

--- a/components/project-details/llm-restaurant-finder.test.tsx
+++ b/components/project-details/llm-restaurant-finder.test.tsx
@@ -1,39 +1,85 @@
-import React from "react";
+import React, { type ReactElement } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { act } from "react-dom/test-utils";
 import { createRoot } from "react-dom/client";
+import LlmRestaurantFinder from "./LlmRestaurantFinder";
+
+const mockedScreenshots = vi.hoisted(
+  () =>
+    [
+      "/llm-restaurant-finder/images/dashboard-overview.png",
+      "/llm-restaurant-finder/images/search-results.png",
+    ] as const,
+);
+
 vi.mock("@/lib/project-images", () => ({
-  getProjectImages: vi.fn(async () => []),
+  getProjectImages: vi.fn(async () => [...mockedScreenshots]),
 }));
 
-vi.mock("./ProjectGallery", () => ({
-  __esModule: true,
-  default: () => <div data-testid="project-gallery" />,
-}));
+vi.mock("./ProjectGallery", () => {
+  interface MockGalleryImage {
+    src: string;
+    alt: string;
+  }
 
-type LlmRestaurantFinderComponent = typeof import("./LlmRestaurantFinder")["default"];
+  const ProjectGalleryMock = ({
+    images,
+  }: {
+    images: MockGalleryImage[];
+  }): ReactElement => (
+    <div>
+      {images.map((img) => (
+        <span
+          key={img.src}
+          role="img"
+          aria-label={img.alt}
+          data-testid="project-gallery-image"
+          data-src={img.src}
+        />
+      ))}
+    </div>
+  );
 
-const loadComponent = async (): Promise<LlmRestaurantFinderComponent> => {
-  const componentModule = await import("./LlmRestaurantFinder");
-  return componentModule.default;
-};
+  return {
+    __esModule: true,
+    default: ProjectGalleryMock,
+  };
+});
 
 (globalThis as { React?: typeof React }).React = React;
 
 describe("LlmRestaurantFinder", () => {
-  it("highlights the Gemini validation and Foursquare mapping steps", async () => {
+  it("highlights the Gemini JSON validation, Foursquare mapping, and access code gate", async () => {
     const container = document.createElement("div");
     document.body.appendChild(container);
     const root = createRoot(container);
-
-    const LlmRestaurantFinder = await loadComponent();
 
     await act(async () => {
       root.render(await LlmRestaurantFinder());
     });
 
-    expect(container.textContent).toContain("Gemini");
-    expect(container.textContent).toContain("Foursquare Places API");
+    const projectImagesModule = await import("@/lib/project-images");
+    expect(vi.mocked(projectImagesModule.getProjectImages)).toHaveBeenCalledWith(
+      "llm-restaurant-finder",
+    );
+
+    const textContent = container.textContent ?? "";
+    expect(textContent).toContain("Gemini generates a JSON command");
+    expect(textContent).toContain("Foursquare Places API parameters");
+    expect(textContent).toContain("rotating access code");
+
+    const galleryImages = container.querySelectorAll("[data-testid='project-gallery-image']");
+    const galleryElements = Array.from(galleryImages);
+    expect(galleryElements.length).toBeGreaterThanOrEqual(mockedScreenshots.length);
+    const renderedSources = galleryElements.map((node) => node.getAttribute("data-src"));
+    mockedScreenshots.forEach((src) => {
+      expect(renderedSources).toContain(src);
+    });
+    expect(
+      galleryElements.some(
+        (node) => node.getAttribute("aria-label") === "LLM Restaurant Finder screenshot",
+      ),
+    ).toBe(true);
 
     root.unmount();
     container.remove();


### PR DESCRIPTION
## Summary
- add a focused test for the LLM Restaurant Finder detail component that mocks project images, validates key copy, and asserts gallery output
- extend dynamic project metadata tests to cover the `llm-restaurant-finder` slug

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1ec3613cc832987db137b3a54a364