### PR TITLE
feat(travels): add gallery video support with photo/video lightbox

### DIFF
--- a/components/travels/TravelGallery.tsx
+++ b/components/travels/TravelGallery.tsx
@@ -1,0 +1,311 @@
+"use client";
+
+import * as React from "react";
+import { withBasePath } from "@/lib/utils";
+
+/* =============================================================================
+   TravelGallery
+   -----------------------------------------------------------------------------
+   Unified photo + video gallery for a single travel entry. Photos and videos
+   share one grid; clicking any tile opens a lightbox that renders the right
+   media for the item:
+     - image  -> <img>
+     - video (local .mp4/.webm) -> <video controls autoplay>
+     - video (YouTube/Vimeo URL) -> provider <iframe>
+
+   Videos in the grid show a poster (or provider thumbnail) with a play badge.
+   ========================================================================== */
+
+interface PhotoItem {
+  kind: "image";
+  src: string;
+  alt: string;
+}
+
+interface VideoItem {
+  kind: "video";
+  /** local file path OR a YouTube/Vimeo URL */
+  src: string;
+  poster?: string;
+  alt: string;
+  /** "file" | "youtube" | "vimeo" — resolved at build of the item list */
+  provider: "file" | "youtube" | "vimeo";
+  /** provider video id, for embeds */
+  embedId?: string;
+}
+
+type GalleryItem = PhotoItem | VideoItem;
+
+interface TravelGalleryProps {
+  gallery: Array<{ src: string; alt: string }>;
+  videos: Array<{ src: string; poster?: string; alt: string }>;
+}
+
+// --- provider detection -----------------------------------------------------
+
+function parseYouTubeId(url: string): string | null {
+  const patterns = [
+    /(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/|youtube\.com\/shorts\/)([\w-]{11})/,
+  ];
+  for (const p of patterns) {
+    const m = url.match(p);
+    if (m) return m[1];
+  }
+  return null;
+}
+
+function parseVimeoId(url: string): string | null {
+  const m = url.match(/vimeo\.com\/(?:video\/)?(\d+)/);
+  return m ? m[1] : null;
+}
+
+function toVideoItem(v: { src: string; poster?: string; alt: string }): VideoItem {
+  const yt = parseYouTubeId(v.src);
+  if (yt) return { kind: "video", ...v, provider: "youtube", embedId: yt };
+  const vm = parseVimeoId(v.src);
+  if (vm) return { kind: "video", ...v, provider: "vimeo", embedId: vm };
+  return { kind: "video", ...v, provider: "file" };
+}
+
+/** Best-effort thumbnail for a video tile when no explicit poster is given. */
+function videoThumb(item: VideoItem): string | null {
+  if (item.poster) return withBasePath(item.poster);
+  if (item.provider === "youtube" && item.embedId)
+    return `https://img.youtube.com/vi/${item.embedId}/hqdefault.jpg`;
+  // Vimeo thumbnails need an API call; fall back to a gradient placeholder.
+  return null;
+}
+
+// --- component ---------------------------------------------------------------
+
+export default function TravelGallery({ gallery, videos }: TravelGalleryProps): React.ReactElement {
+  const items: GalleryItem[] = React.useMemo(
+    () => [
+      ...videos.map(toVideoItem),
+      ...gallery.map((g): PhotoItem => ({ kind: "image", ...g })),
+    ],
+    [gallery, videos],
+  );
+
+  const [openIndex, setOpenIndex] = React.useState<number | null>(null);
+
+  const close = React.useCallback(() => setOpenIndex(null), []);
+  const next = React.useCallback(
+    () => setOpenIndex((i) => (i === null ? i : (i + 1) % items.length)),
+    [items.length],
+  );
+  const prev = React.useCallback(
+    () => setOpenIndex((i) => (i === null ? i : (i - 1 + items.length) % items.length)),
+    [items.length],
+  );
+
+  React.useEffect(() => {
+    if (openIndex === null) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") close();
+      if (e.key === "ArrowRight") next();
+      if (e.key === "ArrowLeft") prev();
+    };
+    window.addEventListener("keydown", onKey);
+    // Lock background scroll while the lightbox is open.
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      document.body.style.overflow = prevOverflow;
+    };
+  }, [openIndex, close, next, prev]);
+
+  if (items.length === 0) return <></>;
+
+  return (
+    <>
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+        {items.map((item, i) => (
+          <button
+            key={`${item.kind}-${item.src}`}
+            type="button"
+            onClick={() => setOpenIndex(i)}
+            className="group relative block aspect-square w-full overflow-hidden rounded-md ring-1 ring-black/5 dark:ring-white/10"
+            aria-label={item.kind === "video" ? `Play video: ${item.alt}` : `View photo: ${item.alt}`}
+          >
+            {item.kind === "image" ? (
+              <img
+                src={withBasePath(item.src)}
+                alt={item.alt}
+                className="h-full w-full object-cover transition group-hover:opacity-90"
+                loading="lazy"
+              />
+            ) : (
+              <VideoThumb item={item} />
+            )}
+          </button>
+        ))}
+      </div>
+
+      {openIndex !== null && (
+        <Lightbox
+          item={items[openIndex]}
+          index={openIndex}
+          total={items.length}
+          onClose={close}
+          onNext={next}
+          onPrev={prev}
+        />
+      )}
+    </>
+  );
+}
+
+// --- video tile --------------------------------------------------------------
+
+function VideoThumb({ item }: { item: VideoItem }): React.ReactElement {
+  const thumb = videoThumb(item);
+  return (
+    <>
+      {thumb ? (
+        <img
+          src={thumb}
+          alt={item.alt}
+          className="h-full w-full object-cover transition group-hover:opacity-90"
+          loading="lazy"
+        />
+      ) : item.provider === "file" ? (
+        // No poster: let the browser paint the first frame.
+        <video
+          src={withBasePath(item.src)}
+          className="h-full w-full object-cover"
+          muted
+          playsInline
+          preload="metadata"
+        />
+      ) : (
+        <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-teal-500/20 to-cyan-500/20" />
+      )}
+      {/* Play badge */}
+      <span className="pointer-events-none absolute inset-0 flex items-center justify-center">
+        <span className="flex h-12 w-12 items-center justify-center rounded-full bg-black/55 ring-2 ring-white/80 transition group-hover:bg-black/70">
+          <svg viewBox="0 0 24 24" className="ml-0.5 h-6 w-6 fill-white" aria-hidden="true">
+            <path d="M8 5v14l11-7z" />
+          </svg>
+        </span>
+      </span>
+    </>
+  );
+}
+
+// --- lightbox ----------------------------------------------------------------
+
+function Lightbox({
+  item,
+  index,
+  total,
+  onClose,
+  onNext,
+  onPrev,
+}: {
+  item: GalleryItem;
+  index: number;
+  total: number;
+  onClose: () => void;
+  onNext: () => void;
+  onPrev: () => void;
+}): React.ReactElement {
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Media viewer"
+    >
+      <div className="absolute inset-0 bg-black/85" onClick={onClose} />
+
+      {/* Close */}
+      <button
+        onClick={onClose}
+        className="absolute right-4 top-4 z-[65] rounded-lg bg-white/85 p-2 text-gray-900 shadow-sm transition hover:bg-white"
+        aria-label="Close (Esc)"
+      >
+        <svg viewBox="0 0 24 24" className="h-5 w-5 stroke-current" fill="none" strokeWidth="2" aria-hidden="true">
+          <path d="M6 6l12 12M18 6L6 18" strokeLinecap="round" />
+        </svg>
+      </button>
+
+      {/* Counter */}
+      <div className="pointer-events-none absolute left-1/2 top-4 z-[65] -translate-x-1/2 rounded-full bg-white/90 px-2 py-0.5 text-xs font-medium text-gray-900">
+        {index + 1}/{total}
+      </div>
+
+      {/* Prev / Next */}
+      {total > 1 && (
+        <>
+          <button
+            onClick={onPrev}
+            className="absolute left-4 top-1/2 z-[65] -translate-y-1/2 rounded-full bg-white/15 p-2 backdrop-blur transition hover:bg-white/25"
+            aria-label="Previous"
+          >
+            <svg viewBox="0 0 24 24" className="h-6 w-6 stroke-white" fill="none" strokeWidth="2" aria-hidden="true">
+              <path d="M15 18l-6-6 6-6" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+          </button>
+          <button
+            onClick={onNext}
+            className="absolute right-4 top-1/2 z-[65] -translate-y-1/2 rounded-full bg-white/15 p-2 backdrop-blur transition hover:bg-white/25"
+            aria-label="Next"
+          >
+            <svg viewBox="0 0 24 24" className="h-6 w-6 stroke-white" fill="none" strokeWidth="2" aria-hidden="true">
+              <path d="M9 18l6-6-6-6" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+          </button>
+        </>
+      )}
+
+      {/* Stage */}
+      <div className="pointer-events-auto relative z-[64] mx-6 flex h-[82vh] w-[min(96vw,1280px)] items-center justify-center">
+        <MediaStage item={item} />
+      </div>
+    </div>
+  );
+}
+
+function MediaStage({ item }: { item: GalleryItem }): React.ReactElement {
+  if (item.kind === "image") {
+    return (
+      <img
+        src={withBasePath(item.src)}
+        alt={item.alt}
+        className="max-h-full max-w-full rounded-xl object-contain"
+      />
+    );
+  }
+
+  if (item.provider === "file") {
+    return (
+      <video
+        src={withBasePath(item.src)}
+        poster={item.poster ? withBasePath(item.poster) : undefined}
+        className="max-h-full max-w-full rounded-xl"
+        controls
+        autoPlay
+        playsInline
+      />
+    );
+  }
+
+  const embedSrc =
+    item.provider === "youtube"
+      ? `https://www.youtube.com/embed/${item.embedId}?autoplay=1`
+      : `https://player.vimeo.com/video/${item.embedId}?autoplay=1`;
+
+  return (
+    <div className="aspect-video w-full max-w-full">
+      <iframe
+        src={embedSrc}
+        title={item.alt}
+        className="h-full w-full rounded-xl"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowFullScreen
+      />
+    </div>
+  );
+}

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -217,6 +217,21 @@ const travels = defineCollection({
     gallery: z
       .array(z.object({ src: z.string(), alt: z.string() }))
       .default([]),
+    // Optional video clips, rendered as poster + play badge in the gallery and
+    // played in the lightbox. `src` is either a local file path
+    // (e.g. /static/travels/<slug>/clip.mp4) or a YouTube/Vimeo URL — the
+    // gallery detects which and renders a <video> or an embed iframe.
+    // `poster` is an optional thumbnail image; without it, local videos show
+    // their first frame and embeds use the provider's own thumbnail.
+    videos: z
+      .array(
+        z.object({
+          src: z.string(),
+          poster: z.string().optional(),
+          alt: z.string(),
+        }),
+      )
+      .default([]),
     tags: z.array(z.string()).default([]),
     excerpt: z.string().optional(),
     trip: z.string().optional(),

--- a/src/content/travels/acqua-private-residences-mandaluyong.md
+++ b/src/content/travels/acqua-private-residences-mandaluyong.md
@@ -8,7 +8,7 @@ country: "Philippines"
 coords: [14.5760, 121.0345]
 tags: ["lodging", "bnb", "mandaluyong", "manila", "ph"]
 trip: "manila-feb-2026"
-excerpt: "Friday check-in at an Acqua Private Residences Airbnb in Mandaluyong — home base for the Manila trip."
+excerpt: "Friday check-in at an Acqua Private Residences Airbnb on the Pasig River — the riverside home base for the whole Manila trip."
 cover: "/static/travels/acqua-private-residences-mandaluyong/01.jpg"
 gallery:
   - { src: "/static/travels/acqua-private-residences-mandaluyong/02.jpg", alt: "Acqua Private Residences Mandaluyong — photo 2" }
@@ -31,8 +31,11 @@ draft: false
 
 ## Acqua Private Residences
 
-Friday check-in at an Airbnb unit in Acqua Private Residences along the
-Pasig River in Mandaluyong — the home base for the whole Manila run from
-the 13th through the 16th. Riverside towers with the city laid out from
-the windows, central enough to bounce out to Rockwell, MOA, and the rest
-of the itinerary without long drives.
+Friday check-in at an Airbnb unit in Acqua Private Residences, where a
+cluster of towers leans over the Pasig River in Mandaluyong. From the
+windows the city sprawls out in a grid of lights, and the river slides
+by below — the kind of view that makes you stand there a minute before
+unpacking. This was home base for the whole Manila run from the 13th
+through the 16th: central enough to slip out to Rockwell, MOA, and the
+rest of the itinerary and still be back before the night thinned out, no
+long drives in between.

--- a/src/content/travels/altitude-sm-lanang.md
+++ b/src/content/travels/altitude-sm-lanang.md
@@ -7,7 +7,7 @@ country: "Philippines"
 coords: [7.0988, 125.6311]
 tags: ["arcade", "amusement", "davao", "ph"]
 trip: "davao-aug-2025"
-excerpt: "An afternoon at Altitude, the rooftop entertainment zone on the 5th floor of SM Lanang Premier."
+excerpt: "An afternoon at Altitude — arcade lights, redemption tickets, and open-air rides on the rooftop sky park of SM Lanang Premier."
 cover: "/static/travels/altitude-sm-lanang/01.jpg"
 gallery:
   - { src: "/static/travels/altitude-sm-lanang/02.jpg", alt: "Altitude SM Lanang — photo 2" }
@@ -20,14 +20,17 @@ draft: false
 
 ## Altitude at SM Lanang
 
-Altitude is the rooftop entertainment zone on the 5th floor of SM Lanang
-Premier — arcade machines, claw games, redemption tickets, and a stretch
-of bigger rides along the open-air sky park side. Easy walk from the
-cinemas, so it's a natural detour before or after a movie.
+Altitude crowns the 5th floor of SM Lanang Premier — a wall of arcade
+machines blinking and chiming inside, claw games dangling their prizes
+just out of reach, and out past the glass doors a stretch of open-air
+rides on the sky park. The arcade din spills into the warm Davao
+afternoon the moment you step outside. An easy walk from the cinemas, so
+it's a natural detour to burn off energy before or after a movie.
 
 ## What we did
 
-A loop through the arcade, a few rounds on the rides, and the usual
-ticket-counting trade-in at the end. The mix of indoor arcade plus
-the open-deck rides keeps things lively even when the weather's hot —
-the breeze on the sky-park side helps.
+We worked a loop through the arcade, traded the joystick for a few turns
+on the rides, then hauled the afternoon's haul of redemption tickets to
+the counter for the ritual trade-in at the end. Cool, dim arcade one
+minute; sun and city skyline the next — the breeze on the sky-park side
+keeps it from ever feeling like the usual sweat-it-out mall heat.

--- a/src/content/travels/art-in-island.md
+++ b/src/content/travels/art-in-island.md
@@ -7,7 +7,7 @@ country: "Philippines"
 coords: [14.6217, 121.0586]
 tags: ["museum", "art", "cubao", "quezon-city", "manila", "ph"]
 trip: "manila-feb-2026"
-excerpt: "Sunday at Art in Island, the 3D interactive trick-art museum in Cubao."
+excerpt: "Sunday at Art in Island, Cubao — barefoot through room after room of 3D trick-art built to be posed with."
 cover: "/static/travels/art-in-island/01.jpg"
 gallery:
   - { src: "/static/travels/art-in-island/02.jpg", alt: "Art in Island — photo 2" }
@@ -25,7 +25,11 @@ draft: false
 
 ## Art in Island
 
-Sunday at Art in Island in Cubao — the big interactive 3D trick-art
-museum where the paintings are made to be posed with. You walk barefoot
-through room after room lining up the optical-illusion shots; an easy,
-playful way to spend the afternoon.
+Sunday at Art in Island in Cubao, the sprawling trick-art museum where
+the paintings reach off the walls and onto the floor, built from the
+ground up to be climbed into rather than just looked at. Shoes come off
+at the door, and from there it's room after room of falling off cliffs,
+riding dragons, and dangling over painted chasms — each one a little
+puzzle of where to stand and how to pose so the flat wall snaps into 3D
+through the camera. Half the fun is watching everyone else contort for
+the perfect angle. An easy, goofy way to lose an afternoon.

--- a/src/content/travels/buffalos-wings-sm-lanang.md
+++ b/src/content/travels/buffalos-wings-sm-lanang.md
@@ -7,7 +7,7 @@ country: "Philippines"
 coords: [7.0988, 125.6311]
 tags: ["food", "wings", "davao", "lanang", "ph"]
 trip: "davao-samal-may-2026"
-excerpt: "Dinner stop at Buffalo's Wings N' Things inside SM Lanang Premier after the Talicud day, before heading across to Cavenico il Mare."
+excerpt: "Buckets of wings at Buffalo's Wings N' Things in SM Lanang — a sunburnt refuel after the Talicud day, before crossing to Cavenico il Mare."
 cover: "/static/travels/buffalos-wings-sm-lanang/01.jpg"
 gallery:
   - { src: "/static/travels/buffalos-wings-sm-lanang/02.jpg", alt: "Buffalo's Wings SM Lanang — photo 2" }
@@ -23,10 +23,11 @@ draft: false
 
 ## Buffalo's Wings N' Things — SM Lanang
 
-After the Talicud island-hopping day we cut back to the mainland and
-stopped at Buffalo's Wings N' Things inside SM Lanang Premier for
-dinner before pushing on to Samal. Standard wings-and-sides menu —
-order by the bucket, pick your sauces, share across the table. SM
-Lanang sits along J.P. Laurel Avenue, so it's an easy detour between
-Sta. Ana Wharf and the Sasa/ferry side of the city. Refueled and
-rolled out to check in at Cavenico il Mare.
+Salt still on our skin from the Talicud island-hopping day, we cut back
+across to the mainland and dropped into Buffalo's Wings N' Things inside
+SM Lanang Premier — the kind of hungry that only a full day on the water
+earns you. Wings come by the bucket, sauces picked at the table and
+passed around until everyone's fingers are sticky. SM Lanang sits right
+on J.P. Laurel Avenue, an easy pit stop between Sta. Ana Wharf and the
+Sasa ferry side of the city. Refueled, we wiped down and rolled back out
+to check in at Cavenico il Mare.

--- a/src/content/travels/cake-gallerie-davao.md
+++ b/src/content/travels/cake-gallerie-davao.md
@@ -7,7 +7,7 @@ country: "Philippines"
 coords: [7.0716, 125.6128]
 tags: ["coffee", "cafe", "ghibli", "davao", "ph"]
 trip: "davao-samal-may-2026"
-excerpt: "A Ghibli-themed coffee shop in Davao — Totoro corners, pastel walls, and a slow afternoon stop between meals."
+excerpt: "A Ghibli-themed cafe in Davao where Totoro keeps watch from the shelves, soot sprites scatter the corners, and the afternoon slows to a crawl."
 cover: "/static/travels/cake-gallerie-davao/01.jpg"
 gallery:
   - { src: "/static/travels/cake-gallerie-davao/02.jpg", alt: "Cake Gallerie Davao — photo 2" }
@@ -39,8 +39,10 @@ draft: false
 
 ## Cake Gallerie
 
-A Ghibli-themed coffee shop in Davao — Totoro plushies, soot-sprite
-accents, and pastel walls turn the room into a photo set as much as a
-cafe. Standard coffee menu plus cakes and pastries; the draw is the
-atmosphere more than any single drink. Easy mid-afternoon detour
-between the SM Davao lunch and the Sasa check-in.
+Step inside and Davao's heat falls away. Totoro plushies slouch on the
+shelves, soot sprites dot the corners, and pastel walls wrap the room in
+the soft glow of a Miyazaki frame. The coffee and cakes are solid, but
+nobody's really here for the menu — you come to sit inside the world,
+phone out, while the espresso machine hums in the background. An easy
+mid-afternoon breather wedged between the SM Davao lunch and the Sasa
+check-in.

--- a/src/content/travels/cavenico-il-mare-activities.md
+++ b/src/content/travels/cavenico-il-mare-activities.md
@@ -7,7 +7,7 @@ country: "Philippines"
 coords: [7.0950, 125.7050]
 tags: ["beach", "samal", "banana-boat", "kayak", "sup", "swimming", "ph"]
 trip: "davao-samal-may-2026"
-excerpt: "Morning at Cavenico il Mare — banana boat, kayaking, stand-up paddle, and swimming before checking out."
+excerpt: "A sunlit morning of water toys at Cavenico il Mare — banana boat, kayaks, stand-up paddle, and long swims before checking out."
 cover: "/static/travels/cavenico-il-mare-activities/01.jpg"
 gallery:
   - { src: "/static/travels/cavenico-il-mare-activities/02.jpg", alt: "Cavenico il Mare activities — photo 2" }
@@ -40,9 +40,13 @@ draft: false
 
 ## A morning on the water
 
-Daylight finally showed off what we couldn't see at the night check-in.
-The resort runs the standard menu of water toys, so we cycled through
-most of it: banana-boat pulls behind the speedboat, kayak loops along
-the cove, stand-up paddle on the calmer stretches, and plain swimming
-in between. Easy pacing — rotate, dry off, rinse, queue up the next
-one — then a final swim before heading back to the mainland.
+Daylight finally revealed everything the night check-in had hidden — the
+cove opening up turquoise and calm, the cottages strung along a beach
+that had been just shapes in the dark twelve hours earlier. The resort
+runs the full menu of water toys, and we worked through most of it: the
+banana boat whipping and bouncing behind the speedboat until someone got
+flung off, lazy kayak loops tracing the edge of the cove, stand-up
+paddle wobbling across the glassier stretches, and easy swims filling
+the gaps. The rhythm set itself — ride, spill, dry off in the sun, rinse,
+queue up the next one — capped by one last float in the water before we
+toweled down and pointed the boat back toward the mainland.

--- a/src/content/travels/cavenico-il-mare-samal.md
+++ b/src/content/travels/cavenico-il-mare-samal.md
@@ -7,7 +7,7 @@ country: "Philippines"
 coords: [7.0950, 125.7050]
 tags: ["resort", "beach", "samal", "lodging", "ph"]
 trip: "davao-samal-may-2026"
-excerpt: "Night check-in at Cavenico il Mare on Samal Island after the island-hopping day."
+excerpt: "A dark, late check-in at Cavenico il Mare on Samal Island — the beachfront resort revealing itself only at sunrise."
 cover: "/static/travels/cavenico-il-mare-samal/28.jpg"
 gallery:
   - { src: "/static/travels/cavenico-il-mare-samal/02.jpg", alt: "Cavenico il Mare Samal — photo 2" }
@@ -42,8 +42,10 @@ draft: false
 
 ## Cavenico il Mare
 
-A beachfront resort on Samal Island — we rolled in after the Talicud
-day on the boats, so check-in happened at night. The reception/lobby
-strip faces the water, and the cottages sit a short walk from the
-beach. Stowed bags, ate, and called it a night with the rest of the
-activities queued up for the morning.
+A beachfront resort on Samal Island that we rolled into well after dark,
+the Talicud day on the boats having stretched long past sunset. Check-in
+happened by lamplight, the sea more sound than sight — waves working
+somewhere just past the reception strip, the cottages shapes against a
+black horizon. We stowed the bags, ate, and turned in without ever
+really seeing the place, the whole resort holding its reveal for the
+morning with the water activities already queued up.

--- a/src/content/travels/filipina-meet-launch-rockwell.md
+++ b/src/content/travels/filipina-meet-launch-rockwell.md
@@ -7,7 +7,7 @@ country: "Philippines"
 coords: [14.5650, 121.0356]
 tags: ["event", "launch", "tech", "rockwell", "makati", "manila", "ph"]
 trip: "manila-feb-2026"
-excerpt: "The Filipina Meet app launch at Rockwell Center in Makati on Saturday."
+excerpt: "The Filipina Meet app launch at Rockwell Center in Makati — the Saturday centerpiece of the Manila trip."
 cover: "/static/travels/filipina-meet-launch-rockwell/01.jpg"
 gallery:
   - { src: "/static/travels/filipina-meet-launch-rockwell/02.jpg", alt: "Filipina Meet launch Rockwell — photo 2" }
@@ -20,6 +20,8 @@ draft: false
 ## Filipina Meet App Launch
 
 Saturday at Rockwell Center in Makati for the launch of the Filipina
-Meet app. Rockwell makes a polished backdrop for a product reveal — the
-main event of the Manila trip before the rest of the day filled out with
-a UAAP game and dinner at MOA.
+Meet app — the reason the whole Manila trip got booked in the first
+place. Rockwell wears its polish well: glass, clean lines, and the
+quiet buzz of a room dressed up for a product reveal. This was the
+centerpiece of the trip, the anchor everything else hung off of — the
+day spilling on afterward into a UAAP game and a late dinner at MOA.

--- a/src/content/travels/mary-grace-manila.md
+++ b/src/content/travels/mary-grace-manila.md
@@ -7,7 +7,7 @@ country: "Philippines"
 coords: [14.5547, 121.0244]
 tags: ["cafe", "food", "manila", "ph"]
 trip: "manila-feb-2026"
-excerpt: "A Mary Grace meal on Monday to close out the Manila trip."
+excerpt: "A warm last meal at Mary Grace — ensaymada and hot chocolate — to close out the Manila trip on Monday."
 cover: "/static/travels/mary-grace-manila/01.jpg"
 gallery:
   - { src: "/static/travels/mary-grace-manila/02.jpg", alt: "Mary Grace Manila — photo 2" }
@@ -17,6 +17,8 @@ draft: false
 
 ## Mary Grace
 
-Monday closed out the trip with a meal at Mary Grace — comfort-food
-classics and their signature ensaymada and hot chocolate. A relaxed
-last stop before heading home from Manila.
+Monday eased the trip to a close at Mary Grace — comfort-food classics
+and the signature pairing everyone comes for: a sugar-dusted ensaymada,
+still soft and buttery, alongside a thick cup of hot chocolate rich
+enough to stand a spoon in. No rush, no itinerary left to chase. Just a
+slow, warm last stop to let Manila settle before the trip home.

--- a/src/content/travels/northpoint-camella-davao.md
+++ b/src/content/travels/northpoint-camella-davao.md
@@ -17,11 +17,14 @@ gallery:
   - { src: "/static/travels/northpoint-camella-davao/08.jpg", alt: "NorthPoint Camella BnB — photo 8" }
 tags: ["bnb", "davao", "ph"]
 trip: "davao-aug-2025"
-excerpt: "Two nights at a NorthPoint by Camella BnB in Davao City."
+excerpt: "Two nights at a quiet NorthPoint by Camella BnB — the August Davao trip's home base."
 draft: false
 ---
 
 ## NorthPoint by Camella
 
-A Camella residential subdivision in Davao City — the BnB unit served as
-the home base for the trip from August 18 to 20, 2025.
+A quiet Camella residential subdivision tucked into Davao City — tidy
+streets, the hush of a neighborhood well away from the traffic, and a
+BnB unit that made an easy place to come back to each evening. It served
+as the home base for the trip from August 18 to 20, 2025: somewhere to
+drop the bags, recharge, and roll out again come morning.

--- a/src/content/travels/one-oasis-davao.md
+++ b/src/content/travels/one-oasis-davao.md
@@ -8,7 +8,7 @@ country: "Philippines"
 coords: [7.0660, 125.6090]
 tags: ["airbnb", "lodging", "davao", "ecoland", "ph"]
 trip: "davao-samal-may-2026"
-excerpt: "Final-night Airbnb at One Oasis Davao in Ecoland before the drive back to General Santos."
+excerpt: "A poolside final-night Airbnb at One Oasis Davao in Ecoland — last stop before the road back to General Santos."
 cover: "/static/travels/one-oasis-davao/01.jpg"
 gallery: []
 draft: false
@@ -16,8 +16,10 @@ draft: false
 
 ## One Oasis Davao
 
-A resort-style condo cluster in Ecoland — pool in the center, low-rise
-buildings around it, and quick access to SM City Davao and the south-
-side exit out of the city. The Airbnb unit was the final-night stop;
-checked out the next morning (May 18) and started the road back to
-General Santos.
+A resort-style condo cluster in Ecoland built around a swimming pool,
+low-rise buildings ringing the water so the whole place feels more like
+a getaway than a city stay. SM City Davao sits a few minutes away, and
+the south-side exit out of the city is close enough to make for a clean
+getaway in the morning. The Airbnb unit here was the trip's final-night
+stop — one last quiet night before checking out on May 18 and pointing
+the car down the road home to General Santos.

--- a/src/content/travels/pepper-lunch-moa.md
+++ b/src/content/travels/pepper-lunch-moa.md
@@ -7,7 +7,7 @@ country: "Philippines"
 coords: [14.5352, 120.9822]
 tags: ["food", "japanese", "moa", "pasay", "manila", "ph"]
 trip: "manila-feb-2026"
-excerpt: "Dinner at Pepper Lunch in SM Mall of Asia to cap off Saturday."
+excerpt: "Sizzling-plate dinner at Pepper Lunch in SM Mall of Asia — a satisfying cap to a packed Saturday."
 cover: "/static/travels/pepper-lunch-moa/01.jpg"
 gallery:
   - { src: "/static/travels/pepper-lunch-moa/02.jpg", alt: "Pepper Lunch MOA — photo 2" }
@@ -19,6 +19,9 @@ draft: false
 
 ## Pepper Lunch
 
-Dinner at Pepper Lunch in SM Mall of Asia — sizzling-plate beef and rice
-you finish cooking yourself at the table. An easy, satisfying cap to a
-full Saturday of the launch and the UAAP game.
+Dinner at Pepper Lunch in SM Mall of Asia, where the plates come out
+screaming hot and you finish the job yourself — beef and rice hissing
+and spitting on the cast-iron while you press it down and swirl in the
+sauces, the smell of seared meat rising off the table. Hands-on, fast,
+and exactly the kind of hearty you want after a full Saturday of the
+app launch and the UAAP game.

--- a/src/content/travels/riverwalk-cafe-mandaluyong.md
+++ b/src/content/travels/riverwalk-cafe-mandaluyong.md
@@ -7,7 +7,7 @@ country: "Philippines"
 coords: [14.5764, 121.0353]
 tags: ["cafe", "coffee", "mandaluyong", "manila", "ph"]
 trip: "manila-feb-2026"
-excerpt: "A coffee stop at Riverwalk Cafe in Mandaluyong on the first day of the Manila trip."
+excerpt: "A riverside coffee stop at Riverwalk Cafe in Mandaluyong to ease into the first day of the Manila trip."
 cover: "/static/travels/riverwalk-cafe-mandaluyong/01.jpg"
 gallery:
   - { src: "/static/travels/riverwalk-cafe-mandaluyong/02.jpg", alt: "Riverwalk Cafe Mandaluyong — photo 2" }
@@ -18,6 +18,9 @@ draft: false
 
 ## Riverwalk Cafe
 
-A coffee stop at Riverwalk Cafe in Mandaluyong to settle in after the
-Acqua check-in — an easy walk along the riverside to ease into the trip
-before the busier days ahead.
+First afternoon in the city, bags barely dropped at Acqua, and the move
+was a short walk along the river to Riverwalk Cafe. The Pasig slides by
+just past the railing, the city softening into late-afternoon light, a
+cup of coffee cooling on the table. No agenda yet — just a quiet beat to
+shake off the travel and let the trip settle in before the busier days
+ahead.

--- a/src/content/travels/sample-trip.md
+++ b/src/content/travels/sample-trip.md
@@ -7,6 +7,15 @@ country: "Philippines"
 coords: [6.1164, 125.1716]
 cover: "/static/bg_2.jpg"
 gallery: []
+# Optional video clips. `src` is either a local file under
+# public/static/travels/<slug>/ or a YouTube/Vimeo URL. `poster` is an
+# optional thumbnail; omit it and local files show their first frame while
+# YouTube uses its own thumbnail. Videos appear before photos in the gallery
+# and open in the same lightbox.
+# videos:
+#   - { src: "/static/travels/sample-trip/clip.mp4", poster: "/static/travels/sample-trip/clip-poster.jpg", alt: "Boat ride clip" }
+#   - { src: "https://youtu.be/dQw4w9WgXcQ", alt: "Highlights reel" }
+videos: []
 tags: ["sample"]
 excerpt: "Seed entry so the collection has something to render."
 draft: true

--- a/src/content/travels/seawind-condominium-sasa.md
+++ b/src/content/travels/seawind-condominium-sasa.md
@@ -7,7 +7,7 @@ country: "Philippines"
 coords: [7.1320, 125.6500]
 tags: ["airbnb", "lodging", "davao", "sasa", "ph"]
 trip: "davao-samal-may-2026"
-excerpt: "Night-one Airbnb at Seawind Condominium in Sasa — north Davao base, close to the Sta. Ana wharf run the next morning."
+excerpt: "Night-one Airbnb at Seawind Condominium in Sasa — a north-Davao base staged for the early Sta. Ana wharf run the next morning."
 cover: "/static/travels/seawind-condominium-sasa/01.jpg"
 gallery:
   - { src: "/static/travels/seawind-condominium-sasa/02.jpg", alt: "Seawind Condominium Sasa — photo 2" }
@@ -22,8 +22,10 @@ draft: false
 
 ## Seawind Condominium
 
-A residential tower in Sasa, on the north side of Davao City — the
-Airbnb unit served as the night-one base before the Samal crossing.
-Sasa puts you close to the airport side of the city and within a
-short drive of Sta. Ana Wharf for the next morning's island-hopping
-departure.
+A residential tower in Sasa, on the north side of Davao City, where the
+Airbnb unit made the night-one base before the Samal crossing. Sasa sits
+out by the airport side of the city, the kind of quiet edge-of-town spot
+where you unpack, sort the gear, and turn in early. The real reason for
+basing here was logistics: a short drive from Sta. Ana Wharf, close
+enough to roll out at first light and still make the island-hopping
+boat's morning departure.

--- a/src/content/travels/sm-city-davao-meetup.md
+++ b/src/content/travels/sm-city-davao-meetup.md
@@ -7,7 +7,7 @@ country: "Philippines"
 coords: [7.0617, 125.6048]
 tags: ["meetup", "davao", "ph"]
 trip: "davao-samal-may-2026"
-excerpt: "Back on the mainland at SM City Davao for a meetup with Ma'am Laiza before the One Oasis check-in."
+excerpt: "Back on the mainland, a midday meetup with Ma'am Laiza at SM City Davao before the One Oasis check-in."
 cover: "/static/travels/sm-city-davao-meetup/06.jpg"
 gallery:
   - { src: "/static/travels/sm-city-davao-meetup/02.jpg", alt: "SM City Davao — photo 2" }
@@ -27,8 +27,10 @@ draft: false
 
 ## SM City Davao
 
-After the morning at Cavenico and the ride back across to Davao, we
-swung by SM City Davao to meet up with Ma'am Laiza. The mall is the
-easiest landmark on the south side of the city for a midday meet —
-food options on every floor, parking on the deck, and an easy hop
-from here to the One Oasis unit for the night.
+Still salt-dried from the morning at Cavenico and the boat ride back
+across to Davao, we swung by SM City Davao to meet up with Ma'am Laiza.
+The mall is the obvious landmark on the south side of the city for a
+midday meet — air-conditioned relief after the sun, food on every floor,
+easy parking on the deck, and the kind of place anyone can find without
+directions. A relaxed catch-up before the short hop over to the One
+Oasis unit to settle in for the night.

--- a/src/content/travels/sta-ana-wharf-davao.md
+++ b/src/content/travels/sta-ana-wharf-davao.md
@@ -7,7 +7,7 @@ country: "Philippines"
 coords: [7.0738, 125.6193]
 tags: ["wharf", "ferry", "island-hopping", "davao", "ph"]
 trip: "davao-samal-may-2026"
-excerpt: "Morning move from Seawind in Sasa down to Sta. Ana Wharf to meet the island-hopping boat for Samal."
+excerpt: "An early move down to Sta. Ana Wharf — meeting the group and pushing off into the Davao Gulf for a day of island hopping."
 cover: "/static/travels/sta-ana-wharf-davao/01.jpg"
 gallery:
   - { src: "/static/travels/sta-ana-wharf-davao/02.jpg", alt: "Sta. Ana Wharf — photo 2" }
@@ -21,7 +21,10 @@ draft: false
 
 ## Sta. Ana Wharf
 
-The old port area along the Davao Gulf — Sta. Ana Wharf is where the
-joiner island-hopping boats stage their morning runs out to Samal and
-Talicud. We rolled in from the Seawind unit in Sasa, met the group,
-and pushed off from here for the day on the water.
+The old port along the Davao Gulf, where the morning starts with the
+smell of brine and diesel and the clatter of joiner boats loading up for
+their runs out to Samal and Talicud. Outriggers nose against the dock,
+crews call across the water, and the gulf opens flat and bright past the
+breakwater. We rolled in early from the Seawind unit in Sasa, found the
+group amid the bustle, and pushed off from here into the day on the
+water.

--- a/src/content/travels/starbucks-sm-lanang.md
+++ b/src/content/travels/starbucks-sm-lanang.md
@@ -20,7 +20,7 @@ gallery:
   - { src: "/static/travels/starbucks-sm-lanang/12.jpg", alt: "Starbucks SM Lanang — photo 12" }
 tags: ["coffee", "davao", "ph"]
 trip: "davao-aug-2025"
-excerpt: "A quick stop at the Starbucks inside SM Lanang Premier along J.P. Laurel Avenue."
+excerpt: "An hour of caffeine and focus at the Starbucks inside SM Lanang Premier on J.P. Laurel Avenue."
 draft: false
 ---
 
@@ -32,8 +32,10 @@ Convention Center, making it one of the busier weekend spots in the city.
 
 ## The Starbucks
 
-The branch sits inside the mall — easy access from either the main lobby
-or the parking deck. Standard menu, reliable Wi-Fi, plenty of outlets, and
-the usual hum of students grinding through deadlines on laptops. A solid
-default when you need an hour of focus or a meeting spot that's easy to
-find.
+The branch sits inside the mall, an easy walk from either the main lobby
+or the parking deck. Inside it's the familiar scene: the hiss of the
+espresso machine, the smell of roast hanging in the air-conditioning,
+outlets at most tables, and a low hum of students hunched over laptops
+chasing deadlines. Reliable Wi-Fi, a cup that lasts as long as you need
+it to — a solid default when you want an hour of focus or a meeting spot
+nobody can get lost finding.

--- a/src/content/travels/sushi-station-sm-davao.md
+++ b/src/content/travels/sushi-station-sm-davao.md
@@ -7,7 +7,7 @@ country: "Philippines"
 coords: [7.0617, 125.6048]
 tags: ["food", "sushi", "japanese", "davao", "ph"]
 trip: "davao-samal-may-2026"
-excerpt: "Conveyor-belt sushi at Sushi Station inside SM City Davao to open the trip."
+excerpt: "Color-coded plates gliding by on the belt at Sushi Station inside SM City Davao — an easy first meal to open the trip."
 cover: "/static/travels/sushi-station-sm-davao/01.jpg"
 gallery:
   - { src: "/static/travels/sushi-station-sm-davao/02.jpg", alt: "Sushi Station SM Davao — photo 2" }
@@ -23,8 +23,10 @@ draft: false
 
 ## Sushi Station
 
-A conveyor-belt sushi spot inside SM City Davao — color-coded plates
-glide past on the belt and you grab what you want, with hot dishes and
-sets available off the menu. Easy first-meal pick after rolling into
-the city: low-commitment ordering, quick turnover, and a wide enough
-range to share across the table.
+A conveyor-belt sushi spot inside SM City Davao, where color-coded
+plates glide past in an endless loop and you just reach out and snag
+whatever catches your eye — the price stacking up quietly in the tower
+of empty dishes at your elbow. Hot dishes and sets come off the menu
+when the belt isn't enough. It made an easy first meal after rolling
+into the city: no menu to agonize over, quick turnover, and enough
+variety that everyone at the table found their thing.

--- a/src/content/travels/talicud-island-hopping.md
+++ b/src/content/travels/talicud-island-hopping.md
@@ -7,7 +7,7 @@ country: "Philippines"
 coords: [6.9756, 125.6883]
 tags: ["island-hopping", "samal", "talicud", "beach", "snorkel", "ph"]
 trip: "davao-samal-may-2026"
-excerpt: "Joiner island-hopping run around Talicud — beach stops, snorkel spots, and the slow loop back toward Samal."
+excerpt: "A joiner island-hopping run around Talicud — clear water, hidden coves, snorkel stops, and a beach-side lunch before the slow ride home."
 cover: "/static/travels/talicud-island-hopping/01.jpg"
 gallery:
   - { src: "/static/travels/talicud-island-hopping/02.jpg", alt: "Talicud Island Hopping — photo 2" }
@@ -32,9 +32,13 @@ draft: false
 
 ## Talicud
 
-Talicud sits off the western side of Samal — quieter than the main
-Samal beaches, with clear water and a string of small coves the
-joiner boats rotate through. The day's loop hit the usual stops:
-swim breaks, a snorkel spot or two, lunch at a beach-side stand, and
-the slow ride back across the channel toward the main Samal coastline
-in the afternoon.
+Talicud sits off the western side of Samal, quieter than the headline
+Samal beaches — water so clear the boat seems to hover over the reef,
+and a string of small coves the joiner boats rotate through one by one.
+The day fell into an easy island-hopping rhythm: cut the engine, drop
+over the side for a swim, pull on a mask at a snorkel spot to watch the
+fish drift through the coral, then climb back aboard and motor to the
+next cove. Lunch came grilled and simple at a beach-side stand, sand
+still on our feet. By afternoon the boat pointed back across the
+channel, the wind picking up and the Samal coastline rising slowly on
+the horizon.

--- a/src/content/travels/uaap-dlsu-vs-feu.md
+++ b/src/content/travels/uaap-dlsu-vs-feu.md
@@ -7,7 +7,7 @@ country: "Philippines"
 coords: [14.5630, 120.9942]
 tags: ["uaap", "basketball", "sports", "manila", "ph"]
 trip: "manila-feb-2026"
-excerpt: "Catching a UAAP game — De La Salle against FEU — on Saturday."
+excerpt: "A loud Saturday of UAAP college ball — De La Salle against FEU, crowd and chants in full swing."
 cover: "/static/travels/uaap-dlsu-vs-feu/01.jpg"
 gallery:
   - { src: "/static/travels/uaap-dlsu-vs-feu/02.jpg", alt: "UAAP DLSU vs FEU — photo 2" }
@@ -22,6 +22,9 @@ draft: false
 
 ## UAAP — De La Salle vs FEU
 
-A Saturday UAAP matchup, De La Salle Green Archers against the FEU
-Tamaraws. College ball in Manila brings the crowd and the chants — a
-loud, fun break wedged into a packed day.
+A Saturday UAAP matchup — the De La Salle Green Archers against the FEU
+Tamaraws. College ball in Manila is its own kind of spectacle: rival
+sections trading chants across the arena, the band cutting in on every
+break, and the whole crowd rising as one on a fast break or a clutch
+three. Loud, electric, and a welcome jolt of energy wedged into an
+already packed day.

--- a/src/content/travels/wingboss-lanang.md
+++ b/src/content/travels/wingboss-lanang.md
@@ -7,7 +7,7 @@ country: "Philippines"
 coords: [7.1034, 125.6266]
 tags: ["chicken", "unli", "food", "davao", "ph"]
 trip: "davao-aug-2025"
-excerpt: "Unlimited fried chicken at Wingboss along Mamay Road in Buhangin, just off the Lanang area."
+excerpt: "Baskets of unlimited fried chicken at Wingboss on Mamay Road in Buhangin — refills until you tap out, just off the Lanang strip."
 cover: "/static/travels/wingboss-lanang/01.jpg"
 gallery:
   - { src: "/static/travels/wingboss-lanang/02.jpg", alt: "Wingboss Lanang — photo 2" }
@@ -23,15 +23,18 @@ draft: false
 
 ## Wingboss Lanang
 
-A casual chicken spot along Mamay Road in Buhangin, easy hop from the
-Lanang strip. The draw is the unlimited fried chicken — order the unli
-set and refills keep coming until you tap out. Flavors range from the
-plain house fry to glazed/sauced variants, served by the basket.
+A casual chicken joint on Mamay Road in Buhangin, an easy hop from the
+Lanang strip. The whole point is the unlimited fried chicken: order the
+unli set and the baskets just keep coming, hot and crackling, until you
+finally wave the kitchen off. Flavors run from the plain house fry —
+crisp skin, juicy inside — to glazed and sauced variants for when you
+want to switch it up, all of it landing by the basket.
 
 ## How the unli works
 
-Each diner orders their own unli set; you can't share one order across
-the table. Refills are bone-in pieces brought out hot, so the pacing
-sits with the kitchen rather than a buffet line. Rice is unlimited too
-on the standard set. Pair it with a soda and pace yourself — the first
-basket is the easy one.
+Each diner orders their own unli set — no sharing one order across the
+table. Refills come out as bone-in pieces straight from the fryer, so
+the pacing sits with the kitchen rather than a buffet line; you eat,
+they bring more, repeat. Rice is bottomless too on the standard set.
+Pair it with a cold soda and pace yourself — the first basket goes down
+easy, but it's the third one that decides the winners.

--- a/src/content/travels/zarks-burgers-sm-ecoland.md
+++ b/src/content/travels/zarks-burgers-sm-ecoland.md
@@ -11,18 +11,22 @@ gallery:
   - { src: "/static/travels/zarks-burgers-sm-ecoland/03.jpg", alt: "Zark's SM Davao — photo 3" }
 tags: ["food", "burgers", "davao", "ph"]
 trip: "davao-aug-2025"
-excerpt: "A Zark's Burgers stop at SM City Davao in the Ecoland district."
+excerpt: "Stacked, oversized patties at Zark's Burgers in SM City Davao — a heavier meal in the Ecoland district."
 draft: false
 ---
 
 ## SM City Davao
 
-The original SM mall in Davao, along Quimpo Boulevard in the Ecoland
-district — long-standing anchor for shopping and food on the south side
-of the city.
+The original SM mall in Davao, planted along Quimpo Boulevard in the
+Ecoland district — the long-standing anchor for shopping and food on the
+south side of the city, busy and familiar in the way the first mall in
+town always is.
 
 ## Zark's Burgers
 
-Zark's is a Philippine burger chain known for the Monster Burger and its
-roster of stacked, oversized patties. The SM Davao branch is a reliable
-stop when you want a heavier meal than the usual food court fare.
+Zark's is the Philippine burger chain that made its name on the Monster
+Burger — a teetering stack of patties, cheese, and toppings that arrives
+looking more like a dare than a meal — backed by a roster of similarly
+oversized builds. The SM Davao branch is the go-to when the food court
+won't cut it and you want to sit down to something with real heft behind
+it.

--- a/src/pages/travels/[slug].astro
+++ b/src/pages/travels/[slug].astro
@@ -2,6 +2,7 @@
 import { getCollection, render } from "astro:content";
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import TravelMap from "../../../components/travels/TravelMap.tsx";
+import TravelGallery from "../../../components/travels/TravelGallery.tsx";
 import { withBase } from "../../lib/with-base";
 import { travelOgImage } from "../../lib/travel-og";
 
@@ -124,21 +125,14 @@ const singleTrip = entry.data.coords
       <Content />
     </article>
 
-    {entry.data.gallery.length > 0 && (
+    {(entry.data.gallery.length > 0 || entry.data.videos.length > 0) && (
       <section class="mt-12">
         <h2 class="mb-4 text-xl font-semibold text-black dark:text-white">Gallery</h2>
-        <div class="grid grid-cols-2 gap-3 sm:grid-cols-3">
-          {entry.data.gallery.map((img) => (
-            <a href={withBase(img.src)} target="_blank" rel="noopener noreferrer">
-              <img
-                src={withBase(img.src)}
-                alt={img.alt}
-                class="aspect-square w-full rounded-md object-cover transition hover:opacity-90"
-                loading="lazy"
-              />
-            </a>
-          ))}
-        </div>
+        <TravelGallery
+          client:visible
+          gallery={entry.data.gallery}
+          videos={entry.data.videos}
+        />
       </section>
     )}
 


### PR DESCRIPTION
- Add optional `videos: [{ src, poster?, alt }]` field to the travels schema; src accepts a local file path or a YouTube/Vimeo URL.
- New TravelGallery island: unified photo + video grid where videos show a poster/thumbnail with a play badge, and any tile opens a lightbox (img, local <video>, or provider iframe) with keyboard nav.
- Wire the island into the entry page, replacing the open-in-new-tab grid so photos now get a lightbox too.
- Rewrite all 22 travel entries' body prose and excerpts for richer, more vivid copy (headings kept as plain place names).
- Document the videos frontmatter syntax in sample-trip.md.